### PR TITLE
Import local package with package name namespace

### DIFF
--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -59,9 +59,12 @@ impl ftd::p2::Library for Library {
                     .join(".packages")
                     .join(package.name.as_str())
             };
-
-            if let Ok(v) = std::fs::read_to_string(path.join(format!("{}.ftd", name))) {
-                return Some((v, current_packages));
+            if name.starts_with(format!("{}:", &lib.config.package.name).as_str()) {
+                if let Some((_, p)) = name.split_once(':') {
+                    if let Ok(v) = std::fs::read_to_string(path.join(format!("{}.ftd", p))) {
+                        return Some((v, current_packages));
+                    }
+                }
             }
 
             if let Some(o) = package.translation_of.as_ref() {
@@ -87,11 +90,17 @@ impl ftd::p2::Library for Library {
                 mut current_packages: Vec<fpm::Package>,
             ) -> Option<(String, Vec<fpm::Package>)> {
                 // Check for Aliases of the packages
+                // Import package non strict. In future, <package_name>:path is strict.
                 for (alias, package) in package.aliases().ok()? {
                     if name.starts_with(&alias) || name.starts_with(package.name.as_str()) {
                         // Non index document
                         let package_path = lib.config.root.join(".packages");
                         let non_alias_name = name.replacen(&alias, package.name.as_str(), 1);
+                        let non_alias_name = non_alias_name.replacen(
+                            ':',
+                            std::path::MAIN_SEPARATOR.to_string().as_str(),
+                            1,
+                        );
                         if let Ok(v) = std::fs::read_to_string(
                             package_path.join(format!("{}.ftd", non_alias_name.as_str())),
                         ) {

--- a/tests/04-import-package-doc/input/amitu/.packages/shobhit.dev/FPM.ftd
+++ b/tests/04-import-package-doc/input/amitu/.packages/shobhit.dev/FPM.ftd
@@ -1,0 +1,4 @@
+-- import: fpm
+
+-- fpm.package: shobhit.dev
+zip: shobhit

--- a/tests/04-import-package-doc/input/amitu/.packages/shobhit.dev/index.ftd
+++ b/tests/04-import-package-doc/input/amitu/.packages/shobhit.dev/index.ftd
@@ -1,0 +1,4 @@
+-- import: shobhit.dev:lib as lib
+
+-- ftd.row s_block:
+background-color: #CCCCCC

--- a/tests/04-import-package-doc/input/amitu/.packages/shobhit.dev/lib.ftd
+++ b/tests/04-import-package-doc/input/amitu/.packages/shobhit.dev/lib.ftd
@@ -1,0 +1,2 @@
+-- ftd.row block:
+background-color: #000000

--- a/tests/04-import-package-doc/input/amitu/FPM.ftd
+++ b/tests/04-import-package-doc/input/amitu/FPM.ftd
@@ -2,3 +2,5 @@
 
 -- fpm.package: amitu
 zip: amitu
+
+-- fpm.dependency: shobhit.dev

--- a/tests/04-import-package-doc/input/amitu/index.ftd
+++ b/tests/04-import-package-doc/input/amitu/index.ftd
@@ -1,5 +1,10 @@
--- import: lib
+-- import: amitu:lib as lib
+-- import: shobhit.dev as shobhit_lib
 
 -- lib.block:
 
 --- ftd.text: hello
+
+-- shobhit_lib.s_block:
+
+--- ftd.text: hello world!


### PR DESCRIPTION
After this PR will have to write:

```ftd
-- import: amitu:foo
```

Instead of the current:

```ftd
-- import: amitu/foo
```

After this `-- import: foo` will always refer to a package named/aliased `foo`, never a module in current package.