### PR TITLE
Added fpm::render function

### DIFF
--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -792,6 +792,67 @@ async fn process_markdown(
     }
 }
 
+// todo: place this function with its dependent function in different file.
+pub(crate) async fn get_ftd(
+    config: &fpm::Config,
+    main: &fpm::Document,
+    base_url: &str,
+    asset_documents: &std::collections::HashMap<String, String>,
+) -> fpm::Result<String> {
+    let new_main = fpm::Document {
+        content: config
+            .package
+            .get_prefixed_body(main.content.as_str(), &main.id, true),
+        id: main.id.to_owned(),
+        parent_path: main.parent_path.to_owned(),
+        package_name: main.package_name.to_owned(),
+    };
+
+    return get_html(config, &new_main, base_url, asset_documents).await;
+
+    async fn get_html(
+        config: &fpm::Config,
+        main: &fpm::Document,
+        base_url: &str,
+        asset_documents: &std::collections::HashMap<String, String>,
+    ) -> fpm::Result<String> {
+        let lib = fpm::Library {
+            config: config.clone(),
+            markdown: None,
+            document_id: main.id.clone(),
+            translated_data: Default::default(),
+            asset_documents: asset_documents.to_owned(),
+            base_url: base_url.to_string(),
+        };
+
+        let main_ftd_doc = match ftd::p2::Document::from(
+            main.id_with_package().as_str(),
+            main.content.as_str(),
+            &lib,
+        ) {
+            Ok(v) => v,
+            Err(e) => {
+                return Err(fpm::Error::PackageError {
+                    message: format!("failed to parse {:?}", &e),
+                });
+            }
+        };
+        let doc_title = match &main_ftd_doc.title() {
+            Some(x) => x.original.clone(),
+            _ => main.id.as_str().to_string(),
+        };
+        let ftd_doc = main_ftd_doc.to_rt("main", &main.id);
+        Ok(replace_markers(
+            fpm::ftd_html(),
+            config,
+            main,
+            doc_title.as_str(),
+            base_url,
+            &ftd_doc,
+        ))
+    }
+}
+
 async fn process_ftd(
     config: &fpm::Config,
     main: &fpm::Document,

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -9,7 +9,7 @@ pub async fn diff(config: &fpm::Config, files: Option<Vec<String>>, all: bool) -
             .collect::<Vec<camino::Utf8PathBuf>>();
         fpm::paths_to_files(config.package.name.as_str(), files, config.root.as_path()).await?
     } else {
-        fpm::get_documents(config, &config.package).await?
+        config.get_files(&config.package).await?
     };
     for doc in documents {
         if let Some(diff) = get_diffy(&doc, &snapshots).await? {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -56,7 +56,7 @@ async fn all_status(
 ) -> fpm::Result<()> {
     let mut file_status = std::collections::BTreeMap::new();
     let mut track_status = std::collections::BTreeMap::new();
-    for doc in fpm::get_documents(config, &config.package).await? {
+    for doc in config.get_files(&config.package).await? {
         let status = get_file_status(&doc, snapshots).await?;
         let track = get_track_status(&doc, snapshots, config.root.as_str())?;
         if !track.is_empty() {

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -7,7 +7,7 @@ pub async fn sync(config: &fpm::Config, files: Option<Vec<String>>) -> fpm::Resu
             .collect::<Vec<camino::Utf8PathBuf>>();
         fpm::paths_to_files(config.package.name.as_str(), files, config.root.as_path()).await?
     } else {
-        fpm::get_documents(config, &config.package).await?
+        config.get_files(&config.package).await?
     };
 
     tokio::fs::create_dir_all(config.history_dir()).await?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -343,13 +343,22 @@ impl Config {
         id: &str,
         package: &fpm::Package,
     ) -> fpm::Result<fpm::File> {
-        self.get_files(package)
+        let file_name = get_file_name(id);
+        return self
+            .get_files(package)
             .await?
             .into_iter()
-            .find(|v| v.get_id().eq(id))
+            .find(|v| v.get_id().eq(file_name.as_str()))
             .ok_or_else(|| fpm::Error::UsageError {
                 message: format!("No such file found: {}", id),
-            })
+            });
+
+        fn get_file_name(id: &str) -> String {
+            if id.eq("/") {
+                return "index.ftd".to_string();
+            }
+            format!("{}.ftd", &id[1..id.len() - 1])
+        }
     }
 
     pub(crate) async fn get_assets(

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,7 +29,7 @@ pub struct Config {
     /// When printing filenames for users consumption we want to print the paths relative to the
     /// `original_directory`, so we keep track of the original directory.
     pub original_directory: camino::Utf8PathBuf,
-    pub extra_data: serde_json::Value,
+    pub extra_data: serde_json::Map<String, serde_json::Value>,
 }
 
 impl Config {
@@ -300,6 +300,14 @@ impl Config {
     /// `attach_data()` sets the value of extra data in fpm::Config,
     /// provided as `data` paramater of type `serde_json::Value`
     pub fn attach_data(&mut self, data: serde_json::Value) -> fpm::Result<()> {
+        let data = match data {
+            serde_json::Value::Object(o) => o,
+            t => {
+                return Err(fpm::Error::UsageError {
+                    message: format!("Expected object type, found: `{:?}`", t),
+                })
+            }
+        };
         self.extra_data = data;
         Ok(())
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use std::convert::TryInto;
 
-/// `Config` struct keeps track of a few configuration parameters that is shared with the entire
+/// `Config` struct keeps track of configuration parameters that is shared with the entire
 /// program. It is constructed from the content of `FPM.ftd` file for the package.
 ///
 /// `Config` is created using `Config::read()` method, and should be constructed only once in the
@@ -157,7 +157,7 @@ impl Config {
     }
 
     /// `read()` is the way to read a Config.
-    pub async fn read() -> fpm::Result<Config> {
+    pub async fn read() -> fpm::Result<fpm::Config> {
         let original_directory: camino::Utf8PathBuf =
             std::env::current_dir()?.canonicalize()?.try_into()?;
         let root = match find_root_for_file(&original_directory, "FPM.ftd") {
@@ -289,6 +289,19 @@ impl Config {
             original_directory,
             extra_data: Default::default(),
         })
+    }
+
+    /// `attach_data_string()` sets the value of extra data in fpm::Config,
+    /// provided as `data` paramater of type `&str`
+    pub fn attach_data_string(&mut self, data: &str) -> fpm::Result<()> {
+        self.attach_data(serde_json::from_str(data)?)
+    }
+
+    /// `attach_data()` sets the value of extra data in fpm::Config,
+    /// provided as `data` paramater of type `serde_json::Value`
+    pub fn attach_data(&mut self, data: serde_json::Value) -> fpm::Result<()> {
+        self.extra_data = data;
+        Ok(())
     }
 }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -67,35 +67,6 @@ pub struct Static {
     pub base_path: camino::Utf8PathBuf,
 }
 
-pub(crate) async fn get_documents(
-    config: &fpm::Config,
-    package: &fpm::Package,
-) -> fpm::Result<Vec<fpm::File>> {
-    let path = if let Some(package_fpm_path) = &package.fpm_path {
-        // TODO: Unwrap?
-        package_fpm_path.parent().unwrap().to_owned()
-    } else if package.name.eq(&config.package.name) {
-        config.root.clone()
-    } else {
-        config.packages_root.clone().join(package.name.as_str())
-    };
-    let mut ignore_paths = ignore::WalkBuilder::new(&path);
-    // ignore_paths.hidden(false); // Allow the linux hidden files to be evaluated
-    ignore_paths.overrides(package_ignores(package, &path)?);
-    let all_files = ignore_paths
-        .build()
-        .into_iter()
-        .flatten()
-        .map(|x| camino::Utf8PathBuf::from_path_buf(x.into_path()).unwrap()) //todo: improve error message
-        .collect::<Vec<camino::Utf8PathBuf>>();
-
-    // TODO: Unwrap?
-    let mut documents = fpm::paths_to_files(package.name.as_str(), all_files, &path).await?;
-    documents.sort_by_key(|v| v.get_id());
-
-    Ok(documents)
-}
-
 pub(crate) async fn paths_to_files(
     package_name: &str,
     files: Vec<camino::Utf8PathBuf>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod document;
 mod font;
 mod i18n;
 mod library;
+mod render;
 mod snapshot;
 mod tracker;
 mod translation;
@@ -32,6 +33,7 @@ pub(crate) use dependency::Dependency;
 pub(crate) use document::{get_documents, get_file, paths_to_files, Document, File, Static};
 pub(crate) use font::Font;
 pub(crate) use library::{FPMLibrary, Library};
+pub use render::render;
 pub(crate) use snapshot::Snapshot;
 pub(crate) use tracker::Track;
 pub(crate) use translation::{TranslatedDocument, TranslationData};
@@ -388,6 +390,9 @@ pub enum Error {
 
     #[error("IoError: {}", _0)]
     ZipError(#[from] zip::result::ZipError),
+
+    #[error("SerdeJsonError: {}", _0)]
+    SerdeJsonError(#[from] serde_json::Error),
 
     #[error("FTDError: {}", _0)]
     FTDError(#[from] ftd::p1::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod auto_import;
 mod commands;
 mod config;
 mod dependency;
-mod document;
+mod file;
 mod font;
 mod i18n;
 mod library;
@@ -30,7 +30,7 @@ pub use commands::{
 pub use config::Config;
 pub(crate) use config::Package;
 pub(crate) use dependency::Dependency;
-pub(crate) use document::{get_documents, get_file, paths_to_files, Document, File, Static};
+pub(crate) use file::{get_file, paths_to_files, Document, File, Static};
 pub(crate) use font::Font;
 pub(crate) use library::{FPMLibrary, Library};
 pub use render::render;

--- a/src/library/get_data.rs
+++ b/src/library/get_data.rs
@@ -27,7 +27,7 @@ pub fn processor(
     }
 
     if let Some((_, ref b)) = section.body {
-        return doc.from_json(&serde_json::from_str::<serde_json::Value>(&b)?, section);
+        return doc.from_json(&serde_json::from_str::<serde_json::Value>(b)?, section);
     }
 
     let caption = match section.caption {
@@ -53,5 +53,5 @@ pub fn processor(
         return doc.from_json(&serde_json::json!(val), section);
     }
 
-    return doc.from_json(&serde_json::json!(caption), section);
+    doc.from_json(&serde_json::json!(caption), section)
 }

--- a/src/library/get_data.rs
+++ b/src/library/get_data.rs
@@ -3,22 +3,55 @@ pub fn processor(
     doc: &ftd::p2::TDoc,
     config: &fpm::Config,
 ) -> ftd::p1::Result<ftd::Value> {
-    let name = if let Some((_, name)) = section.name.rsplit_once(' ') {
-        name.to_string()
-    } else {
-        section.name.to_string()
-    };
-    match config.extra_data.get(name.as_str()) {
-        Some(data) => doc.from_json(data, section),
-        _ => match section.body {
-            Some(ref b) => {
-                doc.from_json(&serde_json::from_str::<serde_json::Value>(&b.1)?, section)
+    let name = match section.header.string(doc.name, section.line_number, "key") {
+        Ok(name) => name,
+        _ => {
+            if let Some((_, name)) = section.name.rsplit_once(' ') {
+                name.to_string()
+            } else {
+                section.name.to_string()
             }
-            _ => Err(ftd::p1::Error::ParseError {
+        }
+    };
+
+    if section.body.is_some() && section.caption.is_some() {
+        return Err(ftd::p1::Error::ParseError {
+            message: "Cannot pass both caption and body".to_string(),
+            doc_id: doc.name.to_string(),
+            line_number: section.line_number,
+        });
+    }
+
+    if let Some(data) = config.extra_data.get(name.as_str()) {
+        return doc.from_json(data, section);
+    }
+
+    if let Some((_, ref b)) = section.body {
+        return doc.from_json(&serde_json::from_str::<serde_json::Value>(&b)?, section);
+    }
+
+    let caption = match section.caption {
+        Some(ref caption) => caption,
+        None => {
+            return Err(ftd::p1::Error::ParseError {
                 message: format!("Value is not passed for {}", name),
                 doc_id: doc.name.to_string(),
                 line_number: section.line_number,
-            }),
-        },
+            })
+        }
+    };
+
+    if let Ok(val) = caption.parse::<bool>() {
+        return doc.from_json(&serde_json::json!(val), section);
     }
+
+    if let Ok(val) = caption.parse::<i64>() {
+        return doc.from_json(&serde_json::json!(val), section);
+    }
+
+    if let Ok(val) = caption.parse::<f64>() {
+        return doc.from_json(&serde_json::json!(val), section);
+    }
+
+    return doc.from_json(&serde_json::json!(caption), section);
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,53 +1,65 @@
 /// `fpm::render()` renders a single ftd file that is part of current FPM package.
 /// It returns `fpm::Result` of rendered HTML as `String`.
 #[allow(dead_code)]
-pub async fn render(config: &fpm::Config, file: &str, base_url: &str) -> fpm::Result<String> {
-    use itertools::Itertools;
+pub async fn render(config: &fpm::Config, id: &str, base_url: &str) -> fpm::Result<String> {
+    let file = config.get_file_by_id(id, &config.package).await?;
+    let asset_documents = config.get_assets(base_url).await?;
 
-    let file = fpm::get_documents(config, &config.package)
-        .await?
-        .into_iter()
-        .find(|v| v.get_id().eq(file))
-        .ok_or_else(|| fpm::Error::UsageError {
-            message: format!("No such file found: {}", file),
-        })?;
-    let dependencies = if let Some(package) = config.package.translation_of.as_ref() {
-        let mut deps = package
-            .get_flattened_dependencies()
-            .into_iter()
-            .unique_by(|dep| dep.package.name.clone())
-            .collect_vec();
-        deps.extend(
-            config
-                .package
-                .get_flattened_dependencies()
-                .into_iter()
-                .unique_by(|dep| dep.package.name.clone()),
-        );
-        deps
-    } else {
-        config
-            .package
-            .get_flattened_dependencies()
-            .into_iter()
-            .unique_by(|dep| dep.package.name.clone())
-            .collect_vec()
-    };
-    let mut asset_documents = std::collections::HashMap::new();
-    asset_documents.insert(
-        config.package.name.clone(),
-        config.package.get_assets_doc(config, base_url).await?,
-    );
-    for dep in &dependencies {
-        asset_documents.insert(
-            dep.package.name.clone(),
-            dep.package.get_assets_doc(config, base_url).await?,
-        );
-    }
-    match file {
-        fpm::File::Ftd(main_doc) => {
-            fpm::commands::build::get_ftd(config, &main_doc, base_url, &asset_documents).await
-        }
+    let main = match file {
+        fpm::File::Ftd(f) => f,
         _ => unimplemented!(),
+    };
+
+    let new_main = fpm::Document {
+        content: config
+            .package
+            .get_prefixed_body(main.content.as_str(), &main.id, true),
+        id: main.id.to_owned(),
+        parent_path: main.parent_path.to_owned(),
+        package_name: main.package_name.to_owned(),
+    };
+
+    return get_html(config, &new_main, base_url, &asset_documents).await;
+
+    async fn get_html(
+        config: &fpm::Config,
+        main: &fpm::Document,
+        base_url: &str,
+        asset_documents: &std::collections::HashMap<String, String>,
+    ) -> fpm::Result<String> {
+        let lib = fpm::Library {
+            config: config.clone(),
+            markdown: None,
+            document_id: main.id.clone(),
+            translated_data: Default::default(),
+            asset_documents: asset_documents.to_owned(),
+            base_url: base_url.to_string(),
+        };
+
+        let main_ftd_doc = match ftd::p2::Document::from(
+            main.id_with_package().as_str(),
+            main.content.as_str(),
+            &lib,
+        ) {
+            Ok(v) => v,
+            Err(e) => {
+                return Err(fpm::Error::PackageError {
+                    message: format!("failed to parse {:?}", &e),
+                });
+            }
+        };
+        let doc_title = match &main_ftd_doc.title() {
+            Some(x) => x.original.clone(),
+            _ => main.id.as_str().to_string(),
+        };
+        let ftd_doc = main_ftd_doc.to_rt("main", &main.id);
+        Ok(fpm::utils::replace_markers(
+            fpm::ftd_html(),
+            config,
+            main.id_to_path().as_str(),
+            doc_title.as_str(),
+            base_url,
+            &ftd_doc,
+        ))
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -7,7 +7,7 @@ pub async fn render(config: &fpm::Config, id: &str, base_url: &str) -> fpm::Resu
 
     let main = match file {
         fpm::File::Ftd(f) => f,
-        _ => unimplemented!(),
+        _ => unreachable!(),
     };
 
     let new_main = fpm::Document {

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,53 @@
+/// `fpm::render()` renders a single ftd file that is part of current FPM package.
+/// It returns `fpm::Result` of rendered HTML as `String`.
+#[allow(dead_code)]
+pub async fn render(config: &fpm::Config, file: &str, base_url: &str) -> fpm::Result<String> {
+    use itertools::Itertools;
+
+    let file = fpm::get_documents(config, &config.package)
+        .await?
+        .into_iter()
+        .find(|v| v.get_id().eq(file))
+        .ok_or_else(|| fpm::Error::UsageError {
+            message: format!("No such file found: {}", file),
+        })?;
+    let dependencies = if let Some(package) = config.package.translation_of.as_ref() {
+        let mut deps = package
+            .get_flattened_dependencies()
+            .into_iter()
+            .unique_by(|dep| dep.package.name.clone())
+            .collect_vec();
+        deps.extend(
+            config
+                .package
+                .get_flattened_dependencies()
+                .into_iter()
+                .unique_by(|dep| dep.package.name.clone()),
+        );
+        deps
+    } else {
+        config
+            .package
+            .get_flattened_dependencies()
+            .into_iter()
+            .unique_by(|dep| dep.package.name.clone())
+            .collect_vec()
+    };
+    let mut asset_documents = std::collections::HashMap::new();
+    asset_documents.insert(
+        config.package.name.clone(),
+        config.package.get_assets_doc(config, base_url).await?,
+    );
+    for dep in &dependencies {
+        asset_documents.insert(
+            dep.package.name.clone(),
+            dep.package.get_assets_doc(config, base_url).await?,
+        );
+    }
+    match file {
+        fpm::File::Ftd(main_doc) => {
+            fpm::commands::build::get_ftd(config, &main_doc, base_url, &asset_documents).await
+        }
+        _ => unimplemented!(),
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -205,6 +205,48 @@ pub(crate) fn validate_zip_url(package: &fpm::Package) -> fpm::Result<()> {
     Ok(())
 }
 
+pub(crate) fn replace_markers(
+    s: &str,
+    config: &fpm::Config,
+    main_id: &str,
+    title: &str,
+    base_url: &str,
+    main_rt: &ftd::Document,
+) -> String {
+    s.replace("__ftd_doc_title__", title)
+        .replace(
+            "__ftd_canonical_url__",
+            config.package.generate_canonical_url(main_id).as_str(),
+        )
+        .replace("__ftd_js__", fpm::ftd_js().as_str())
+        .replace("__ftd_body_events__", main_rt.body_events.as_str())
+        .replace("__ftd_css__", fpm::ftd_css())
+        .replace("__fpm_js__", fpm::fpm_js())
+        .replace(
+            "__ftd_data_main__",
+            fpm::font::escape(
+                serde_json::to_string_pretty(&main_rt.data)
+                    .expect("failed to convert document to json")
+                    .as_str(),
+            )
+            .as_str(),
+        )
+        .replace(
+            "__ftd_external_children_main__",
+            fpm::font::escape(
+                serde_json::to_string_pretty(&main_rt.external_children)
+                    .expect("failed to convert document to json")
+                    .as_str(),
+            )
+            .as_str(),
+        )
+        .replace(
+            "__main__",
+            format!("{}{}", main_rt.html, config.get_font_style(),).as_str(),
+        )
+        .replace("__base_url__", base_url)
+}
+
 pub fn is_test() -> bool {
     std::env::args().any(|e| e == "--test")
 }


### PR DESCRIPTION
`fpm::render()` renders a single `ftd` file that is part of current FPM package.
It returns `fpm::Result` of rendered HTML as `String`.

Requirements: [requirement: fpm::render() #3@FifthTry/fpm.dev](https://github.com/FifthTry/fpm.dev/pull/3). 