### PR TITLE
no-static flag added for fpm build 

### DIFF
--- a/src/commands/build2.rs
+++ b/src/commands/build2.rs
@@ -19,7 +19,7 @@ pub async fn build2(
             main.get_id()
         );
 
-        // No need to build static files when file is passed (no-static behaviour)
+        // No need to build static files when file is passed during fpm build (no-static behaviour)
         let no_static: bool = file.is_some();
 
         match main {

--- a/src/commands/build2.rs
+++ b/src/commands/build2.rs
@@ -24,10 +24,14 @@ pub async fn build2(
                         start,
                     );
                     continue;
-                },
+                }
                 _ => {
-                    println!("Allowing file = {}/{}",config.package.name.as_str(), main.get_id())
-                },
+                    println!(
+                        "Allowing file = {}/{}",
+                        config.package.name.as_str(),
+                        main.get_id()
+                    )
+                }
             }
         }
 

--- a/src/commands/build2.rs
+++ b/src/commands/build2.rs
@@ -18,11 +18,6 @@ pub async fn build2(
         if no_static {
             match main {
                 fpm::File::Static(_) | fpm::File::Image(_) | fpm::File::Code(_) => {
-                    fpm::utils::print_end(
-                        format!("Ignored {}/{}", config.package.name.as_str(), main.get_id())
-                            .as_str(),
-                        start,
-                    );
                     continue;
                 }
                 _ => {}

--- a/src/commands/build2.rs
+++ b/src/commands/build2.rs
@@ -3,7 +3,6 @@ pub async fn build2(
     file: Option<&str>,
     base_url: &str,
     ignore_failed: bool,
-    no_static: bool,
 ) -> fpm::Result<()> {
     tokio::fs::create_dir_all(config.build_dir()).await?;
     let documents = get_documents_for_current_package(config).await?;
@@ -14,21 +13,14 @@ pub async fn build2(
         config.current_document = Some(main.get_id());
         let start = std::time::Instant::now();
 
-        // Ignoring static files if --no-static flag is used
-        if no_static {
-            match main {
-                fpm::File::Static(_) | fpm::File::Image(_) | fpm::File::Code(_) => {
-                    continue;
-                }
-                _ => {}
-            }
-        }
-
         print!(
             "Processing {}/{} ... ",
             config.package.name.as_str(),
             main.get_id()
         );
+
+        // No need to build static files when file is passed (no-static behaviour)
+        let no_static: bool = file.is_some();
 
         match main {
             fpm::File::Ftd(doc) => {

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -306,12 +306,6 @@ async fn resolve_foreign_variable2(
                         format!("Processed {}/{}", package.name.as_str(), light_path).as_str(),
                         start,
                     );
-                } else if !download_assets {
-                    let start = std::time::Instant::now();
-                    fpm::utils::print_end(
-                        format!("Ignored {}/{}", package.name.as_str(), light_path).as_str(),
-                        start,
-                    );
                 }
 
                 if light {

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -306,6 +306,12 @@ async fn resolve_foreign_variable2(
                         format!("Processed {}/{}", package.name.as_str(), light_path).as_str(),
                         start,
                     );
+                } else if !download_assets {
+                    let start = std::time::Instant::now();
+                    fpm::utils::print_end(
+                        format!("Ignored {}/{}", package.name.as_str(), light_path).as_str(),
+                        start,
+                    );
                 }
 
                 if light {

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ async fn main() -> fpm::Result<()> {
             build.value_of("file"),
             build.value_of("base").unwrap(), // unwrap okay because base is required
             build.is_present("ignore-failed"),
+            build.is_present("no-static"),
         )
         .await?;
     }
@@ -170,6 +171,14 @@ fn app(authors: &'static str, version: &'static str) -> clap::App<'static, 'stat
                         .short("v")
                         .takes_value(false)
                         .required(false),
+                )
+                // --no-static flag to ignore building of static files
+                .arg( clap::Arg::with_name("no-static")
+                    .long("no-static")
+                    .short("ns")
+                    .takes_value(false)
+                    .required(false)
+                    .help("ignores static files while building")
                 )
                 .version(env!("CARGO_PKG_VERSION")),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,15 +43,12 @@ async fn main() -> fpm::Result<()> {
         if build.is_present("verbose") {
             println!("{}", fpm::debug_env_vars());
         }
-        // Build only non-static files when file is passed
-        let no_static: bool = build.value_of("file").is_some();
 
         fpm::build2(
             &mut config,
             build.value_of("file"),
             build.value_of("base").unwrap(), // unwrap okay because base is required
             build.is_present("ignore-failed"),
-            no_static,
         )
         .await?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,12 +43,15 @@ async fn main() -> fpm::Result<()> {
         if build.is_present("verbose") {
             println!("{}", fpm::debug_env_vars());
         }
+        // Build only non-static files when file or --no-static flag is passed
+        let no_static: bool = build.value_of("file").is_some() || build.is_present("no-static");
+
         fpm::build2(
             &mut config,
             build.value_of("file"),
             build.value_of("base").unwrap(), // unwrap okay because base is required
             build.is_present("ignore-failed"),
-            build.is_present("no-static"),
+            no_static,
         )
         .await?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,8 @@ async fn main() -> fpm::Result<()> {
         if build.is_present("verbose") {
             println!("{}", fpm::debug_env_vars());
         }
-        // Build only non-static files when file or --no-static flag is passed
-        let no_static: bool = build.value_of("file").is_some() || build.is_present("no-static");
+        // Build only non-static files when file is passed
+        let no_static: bool = build.value_of("file").is_some();
 
         fpm::build2(
             &mut config,
@@ -174,14 +174,6 @@ fn app(authors: &'static str, version: &'static str) -> clap::App<'static, 'stat
                         .short("v")
                         .takes_value(false)
                         .required(false),
-                )
-                // --no-static flag to ignore building of static files
-                .arg( clap::Arg::with_name("no-static")
-                    .long("no-static")
-                    .short("ns")
-                    .takes_value(false)
-                    .required(false)
-                    .help("ignores static files while building")
                 )
                 .version(env!("CARGO_PKG_VERSION")),
         )

--- a/src/package_doc.rs
+++ b/src/package_doc.rs
@@ -348,6 +348,7 @@ pub(crate) async fn process_ftd(
     config: &mut fpm::Config,
     main: &fpm::Document,
     base_url: &str,
+    no_static: bool,
 ) -> fpm::Result<Vec<u8>> {
     let current_package = config
         .all_packages
@@ -406,7 +407,7 @@ pub(crate) async fn process_ftd(
         )
     };
 
-    let response = read_ftd(config, &main, base_url, true).await?;
+    let response = read_ftd(config, &main, base_url, !no_static).await?;
     fpm::utils::write(
         &config.build_dir(),
         file_rel_path.as_str(),


### PR DESCRIPTION
- flag added to ignore building of static files when fpm build is used 
- use either -ns or --no-static