### PR TITLE
fixed aliased imports in body to full path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1258,53 +1258,55 @@ impl Package {
         })
     }
 
-    /// will map import aliases to full path with alias in the actual body of the document
+    /// will map aliased imports to full path in the actual body of the document
+    /// and return the new document body as string
     ///
-    /// eg. -- import: res
-    ///          will be mapped to
-    ///     -- import full_path_of_res as res
+    /// [-- import: some_alias] will be mapped to
+    /// [-- import full_path_of_some_alias as some_alias]
+
     pub fn fix_imports_in_body(&self, body: &str, id: &str) -> ftd::p1::Result<String> {
         let mut new_body = String::new();
 
         let mut ln = 1;
         for line in body.lines() {
             let line_string = line.trim();
-            let mut final_line = line_string.to_string();
 
-            if line_string.starts_with("-- import") && !line_string.contains(" as ") {
-                // Import statement (All possible cases)
-                // [-- import: full_path] (pass this)
-                // [-- import: alias] -> convert this to -> [--import: full_path as alias]
-                // [-- import: full_path as alias] (pass this)
+            // Import statement (All possible cases)
+            // [-- import: full_path] (pass this)
+            // [-- import: alias] -> convert this to -> [--import: full_path as alias]
+            // [-- import: full_path as alias] (pass this)
+            let final_line =
+                if line_string.starts_with("-- import") && !line_string.contains(" as ") {
+                    let import_tokens: Vec<&str> = line_string.split(':').collect();
+                    if import_tokens.len() <= 1 {
+                        return Err(ftd::p1::Error::ParseError {
+                            message: "Import content missing !!".to_string(),
+                            doc_id: id.to_string(),
+                            line_number: ln,
+                        });
+                    }
 
-                let import_tokens: Vec<&str> = line_string.split(':').collect();
-                if import_tokens.len() <= 1 {
-                    return Err(ftd::p1::Error::ParseError {
-                        message: "Import content missing !!".to_string(),
-                        doc_id: id.to_string(),
-                        line_number: ln,
-                    });
-                }
+                    // Initial import content from the doc
+                    let mut import_content = String::from(import_tokens[1].trim());
 
-                let mut import_content = String::new();
-                import_content.push_str(import_tokens[1].trim());
-
-                for dependency in &self.dependencies {
-                    if let Some(dep_alias) = &dependency.alias {
-                        if dep_alias.as_str().eq(import_content.as_str()) {
-                            import_content =
-                                format!("{} as {}", dependency.package.name, dep_alias);
+                    // Update the import content to full path if dependency alias is used
+                    for dependency in &self.dependencies {
+                        if let Some(dep_alias) = &dependency.alias {
+                            if dep_alias.as_str().eq(import_content.as_str()) {
+                                import_content =
+                                    format!("{} as {}", dependency.package.name, dep_alias);
+                            }
                         }
                     }
-                }
 
-                let mut final_string = String::new();
-                final_string.push_str(import_tokens[0]);
-                final_string.push_str(": ");
-                final_string.push_str(&import_content);
-
-                final_line = final_string;
-            }
+                    // Final import statement
+                    // -- import: [import_content]
+                    let final_string = format!("{}: {}", import_tokens[0], import_content);
+                    final_string
+                } else {
+                    // No change in line push as it is
+                    line_string.to_string()
+                };
 
             new_body.push_str(&final_line);
             new_body.push('\n');

--- a/src/config.rs
+++ b/src/config.rs
@@ -1258,25 +1258,140 @@ impl Package {
         })
     }
 
+    /// returns the full path of the import from alias if valid
+    /// otherwise returns None
+    pub fn get_full_path_from_alias(&self, alias: &str) -> Option<String>{
+        let mut full_path: Option<String> = None;
+
+        for dependency in &self.dependencies {
+            if let Some(dep_alias) = &dependency.alias {
+                if dep_alias.as_str().eq(alias) {
+                    full_path = Some(format!("{}", dependency.package.name));
+                }
+            }
+        }
+
+        full_path
+    }
+
+    /// returns expanded import path given Type-1 aliased import content
+    ///
+    /// Type-1 aliased imports
+    ///
+    /// -- import alias/x.. as alias_2
+    ///
+    /// -- import alias/x.. as alias_2
+    pub fn fix_import_as_type(&self, import_content: &str, id: &str, line_number: usize) -> ftd::p1::Result<String>{
+
+        let mut parts = import_content.splitn(2," as ");
+
+        match (parts.next(), parts.next()){
+            (Some(front), Some(alias)) => {
+                // case 3: -- import alias/x.. as alias_2
+                // map:    -- import full_path_of_alias/x.. as alias_2
+                // case 4: -- import alias as alias_2
+                // map:    -- import full_path_of_alias as alias_2
+
+                let extended_front = self.fix_import_non_as_type(front,id,line_number,false)?;
+                Ok(format!("{} as {}",extended_front, alias))
+            },
+            _ => {
+                // Throw error for unknown as-type import
+                Err(ftd::p1::Error::ParseError {
+                    message: "invalid import !! (type-1)".to_string(),
+                    doc_id: id.to_string(),
+                    line_number
+                })
+            }
+        }
+    }
+
+    /// returns expanded import path given Type-2 aliased import content
+    ///
+    /// Type-2 aliased imports
+    ///
+    /// -- import alias
+    ///
+    /// -- import alias/x..
+    pub fn fix_import_non_as_type(&self, import_content: &str, id: &str, line_number: usize, with_alias: bool) -> ftd::p1::Result<String>{
+
+        // if with-alias is true
+        // and the import content is an alias itself then
+        // the extended path will be returned with alias
+        // like this -- import: full_path_of_alias as alias
+        // instead of -- import: full_path_of_alias
+
+        let mut parts = import_content.splitn(2,"/");
+        match (parts.next(), parts.next()) {
+            (Some(front), Some(rem)) =>  {
+                // case 2: -- import alias/x..
+                // map: -- import full_path_of_alias/x..
+
+                let extended_path_of_alias = self.get_full_path_from_alias(front);
+                match extended_path_of_alias{
+                    Some(ext_path) => Ok(format!("{}/{}", ext_path, rem)),
+                    None => Ok(format!("{}/{}", front, rem)),
+                }
+            },
+            (Some(front), None) => {
+                // case 1: -- import alias
+                // map: -- import full_path_of_alias as alias
+
+                let extended_path_of_alias = self.get_full_path_from_alias(front);
+                match extended_path_of_alias{
+                    Some(ext_path) => {
+                        match with_alias{
+                            true => Ok(format!("{} as {}", ext_path, front)),
+                            false => Ok(format!("{}", ext_path)),
+                        }
+                    },
+                    None => Ok(format!("{}", front)),
+                }
+            },
+            _ => {
+                // Throw error for unknown non-as-type import
+                Err(ftd::p1::Error::ParseError {
+                    message: "invalid import !! (type-2)".to_string(),
+                    doc_id: id.to_string(),
+                    line_number
+                })
+            }
+        }
+    }
+
     /// will map aliased imports to full path in the actual body of the document
     /// and return the new document body as string
     ///
-    /// [-- import: some_alias] will be mapped to
-    /// [-- import full_path_of_some_alias as some_alias]
-
+    /// In ftd files apart from FPM.ftd
+    ///
+    /// case 1: -- import alias
+    ///
+    /// map:    -- import full_path_of_alias as alias
+    ///
+    /// case 2: -- import alias/x..
+    ///
+    /// map:    -- import full_path_of_alias/x..
+    ///
+    /// case 3: -- import alias/x.. as alias_2
+    ///
+    /// map:    -- import full_path_of_alias/x.. as alias_2
+    ///
+    /// case 4: -- import alias as alias_2
+    ///
+    /// map:    -- import full_path_of_alias as alias_2
+    ///
     pub fn fix_imports_in_body(&self, body: &str, id: &str) -> ftd::p1::Result<String> {
-        let mut new_body = String::new();
 
+        let mut new_body = String::new();
         let mut ln = 1;
+
         for line in body.lines() {
             let line_string = line.trim();
 
-            // Import statement (All possible cases)
-            // [-- import: full_path] (pass this)
-            // [-- import: alias] -> convert this to -> [--import: full_path as alias]
-            // [-- import: full_path as alias] (pass this)
-            let final_line =
-                if line_string.starts_with("-- import") && !line_string.contains(" as ") {
+            let final_line = {
+                if line_string.starts_with("-- import") {
+
+                    // Split [-- import | content]
                     let import_tokens: Vec<&str> = line_string.split(':').collect();
                     if import_tokens.len() <= 1 {
                         return Err(ftd::p1::Error::ParseError {
@@ -1289,27 +1404,22 @@ impl Package {
                     // Initial import content from the doc
                     let mut import_content = String::from(import_tokens[1].trim());
 
-                    // Update the import content to full path if dependency alias is used
-                    for dependency in &self.dependencies {
-                        if let Some(dep_alias) = &dependency.alias {
-                            if dep_alias.as_str().eq(import_content.as_str()) {
-                                import_content =
-                                    format!("{} as {}", dependency.package.name, dep_alias);
-                            }
-                        }
-                    }
+                    import_content = match import_content.contains(" as ") {
+                        true => self.fix_import_as_type(import_content.as_str(), id, ln)?,
+                        false => self.fix_import_non_as_type(import_content.as_str(), id, ln, true)?
+                    };
 
-                    // Final import statement
-                    // -- import: [import_content]
-                    let final_string = format!("{}: {}", import_tokens[0], import_content);
-                    final_string
+                    format!("-- import: {}", &import_content)
+
                 } else {
                     // No change in line push as it is
                     line_string.to_string()
-                };
+                }
+            };
 
             new_body.push_str(&final_line);
             new_body.push('\n');
+
             ln += 1;
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1264,39 +1264,36 @@ impl Package {
     ///          will be mapped to
     ///     -- import full_path_of_res as res
     pub fn fix_imports_in_body(&self, body: &str, id: &str) -> ftd::p1::Result<String> {
-
         let mut new_body = String::new();
 
         let mut ln = 1;
-        for line in body.lines(){
-
+        for line in body.lines() {
             let line_string = line.trim();
             let mut final_line = line_string.to_string();
 
-            if line_string.starts_with("-- import") && !line_string.contains(" as "){
-
+            if line_string.starts_with("-- import") && !line_string.contains(" as ") {
                 // Import statement (All possible cases)
                 // [-- import: full_path] (pass this)
                 // [-- import: alias] -> convert this to -> [--import: full_path as alias]
                 // [-- import: full_path as alias] (pass this)
 
                 let import_tokens: Vec<&str> = line_string.split(':').collect();
-                if import_tokens.len() <= 1{
+                if import_tokens.len() <= 1 {
                     return Err(ftd::p1::Error::ParseError {
                         message: "Import content missing !!".to_string(),
                         doc_id: id.to_string(),
-                        line_number: ln
-                    })
+                        line_number: ln,
+                    });
                 }
 
                 let mut import_content = String::new();
                 import_content.push_str(import_tokens[1].trim());
 
-                for dependency in &self.dependencies{
-                    if let Some(dep_alias) = &dependency.alias
-                    {
-                        if dep_alias.as_str().eq(import_content.as_str()){
-                            import_content = format!("{} as {}",dependency.package.name, dep_alias);
+                for dependency in &self.dependencies {
+                    if let Some(dep_alias) = &dependency.alias {
+                        if dep_alias.as_str().eq(import_content.as_str()) {
+                            import_content =
+                                format!("{} as {}", dependency.package.name, dep_alias);
                         }
                     }
                 }
@@ -1311,7 +1308,7 @@ impl Package {
 
             new_body.push_str(&final_line);
             new_body.push('\n');
-            ln = ln + 1;
+            ln += 1;
         }
 
         Ok(new_body)

--- a/src/package_doc.rs
+++ b/src/package_doc.rs
@@ -304,9 +304,7 @@ pub(crate) async fn read_ftd(
 
     let main_ftd_doc = match fpm::doc::parse2(
         main.id_with_package().as_str(),
-        current_package
-            .get_prefixed_body(main.content.as_str(), &main.id, true)
-            .as_str(),
+        main.content.as_str(),
         &mut lib,
         base_url,
         download_assets,

--- a/src/package_doc.rs
+++ b/src/package_doc.rs
@@ -393,6 +393,7 @@ pub(crate) async fn process_ftd(
                 )
             }
         } else {
+            main.content = current_package.fix_imports_in_body(main.content.as_str(), main.id.as_str())?;
             main.content = current_package.get_prefixed_body(main.content.as_str(), &main.id, true);
         }
         main

--- a/src/package_doc.rs
+++ b/src/package_doc.rs
@@ -393,7 +393,8 @@ pub(crate) async fn process_ftd(
                 )
             }
         } else {
-            main.content = current_package.fix_imports_in_body(main.content.as_str(), main.id.as_str())?;
+            main.content =
+                current_package.fix_imports_in_body(main.content.as_str(), main.id.as_str())?;
             main.content = current_package.get_prefixed_body(main.content.as_str(), &main.id, true);
         }
         main

--- a/src/package_doc.rs
+++ b/src/package_doc.rs
@@ -302,9 +302,15 @@ pub(crate) async fn read_ftd(
         packages_under_process: vec![current_package.name.to_string()],
     };
 
+    // Get Prefix Body => [AutoImports + Actual Doc content]
+    let mut doc_content =
+        current_package.get_prefixed_body(main.content.as_str(), main.id.as_str(), true);
+    // Fix aliased imports to full path (if any)
+    doc_content = current_package.fix_imports_in_body(doc_content.as_str(), main.id.as_str())?;
+
     let main_ftd_doc = match fpm::doc::parse2(
         main.id_with_package().as_str(),
-        main.content.as_str(),
+        doc_content.as_str(),
         &mut lib,
         base_url,
         download_assets,
@@ -348,11 +354,6 @@ pub(crate) async fn process_ftd(
     base_url: &str,
     no_static: bool,
 ) -> fpm::Result<Vec<u8>> {
-    let current_package = config
-        .all_packages
-        .get(main.package_name.as_str())
-        .unwrap_or(&config.package);
-
     if main.id.eq("FPM.ftd") {
         tokio::fs::copy(
             config.root.join(main.id.as_str()),
@@ -380,20 +381,11 @@ pub(crate) async fn process_ftd(
                     Some(dep) => dep.package.name.as_str(),
                     None => fpm::PACKAGE_INFO_INTERFACE,
                 };
-                config.package.get_prefixed_body(
-                    format!(
-                        "-- import: {}/package-info as pi\n\n-- pi.package-info-page:",
-                        package_info_package
-                    )
-                    .as_str(),
-                    &main.id,
-                    true,
+                format!(
+                    "-- import: {}/package-info as pi\n\n-- pi.package-info-page:",
+                    package_info_package
                 )
             }
-        } else {
-            main.content =
-                current_package.fix_imports_in_body(main.content.as_str(), main.id.as_str())?;
-            main.content = current_package.get_prefixed_body(main.content.as_str(), &main.id, true);
         }
         main
     };


### PR DESCRIPTION
- mapped import aliases in actual doc to full path after generating prefix body
- removed unnecessary calling of getPrefixBody() before parsing which used to attach autoimport contents twice on top of the actual document.