### PR TITLE
added favicon support

### DIFF
--- a/ftd.html
+++ b/ftd.html
@@ -3,8 +3,7 @@
     <head>
         <meta charset="UTF-8"><base href="__base_url__">
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">__ftd_canonical_url__
-        <title>__ftd_doc_title__</title>
-        __favicon_html_tag__
+        <title>__ftd_doc_title__</title>__favicon_html_tag__
         <script type="ftd" id="ftd-data">__ftd_data_main__</script>
         <script type="ftd" id="ftd-external-children">__ftd_external_children_main__</script>
         <style>__ftd_css____ftd_element_css__</style>

--- a/ftd.html
+++ b/ftd.html
@@ -4,6 +4,7 @@
         <meta charset="UTF-8"><base href="__base_url__">
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0">__ftd_canonical_url__
         <title>__ftd_doc_title__</title>
+        __favicon_html_tag__
         <script type="ftd" id="ftd-data">__ftd_data_main__</script>
         <script type="ftd" id="ftd-external-children">__ftd_external_children_main__</script>
         <style>__ftd_css____ftd_element_css__</style>

--- a/ftd/fpm.ftd
+++ b/ftd/fpm.ftd
@@ -4,6 +4,7 @@ boolean versioned: false
 optional body about:
 optional string zip:
 optional string base:
+optional string favicon:
 optional string language:
 optional string translation-of:
 string list translation:

--- a/src/config.rs
+++ b/src/config.rs
@@ -1057,6 +1057,8 @@ pub(crate) struct PackageTemp {
     pub canonical_url: Option<String>,
     #[serde(rename = "inherit-auto-imports-from-original")]
     pub import_auto_imports_from_original: bool,
+    #[serde(rename = "favicon")]
+    pub favicon: Option<String>,
 }
 
 impl PackageTemp {
@@ -1090,6 +1092,7 @@ impl PackageTemp {
             fonts: vec![],
             import_auto_imports_from_original: self.import_auto_imports_from_original,
             sitemap: None,
+            favicon: self.favicon,
         }
     }
 }
@@ -1126,6 +1129,14 @@ pub struct Package {
     /// and table of content (`toc`). This automatically converts the documents in package into the
     /// corresponding to structure.
     pub sitemap: Option<String>,
+    /// Optional path for favicon icon to be used.
+    ///
+    /// By default if any file favicon.* is present in package and favicon is not specified
+    /// in FPM.ftd, that file will be used.
+    ///
+    /// If more than one favicon.* file is present, we will use them
+    /// in following priority: .ico > .svg > .png > .jpg.
+    pub favicon: Option<String>,
 }
 
 impl Package {
@@ -1148,6 +1159,7 @@ impl Package {
             fonts: vec![],
             import_auto_imports_from_original: true,
             sitemap: None,
+            favicon: None,
         }
     }
 

--- a/src/library/fpm_dot_ftd.rs
+++ b/src/library/fpm_dot_ftd.rs
@@ -767,5 +767,9 @@ fn capital_fpm(lib: &fpm::Library) -> String {
         s.push_str(format!("zip: {}", zip).as_str());
     }
 
+    if let Some(ref favicon) = lib.config.package.favicon {
+        s.push_str(format!("\nfavicon: {}", favicon).as_str());
+    }
+
     s
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -284,19 +284,19 @@ fn resolve_favicon(
 
                 // Just check if any favicon exists in the root package directory
                 // in the above mentioned priority order
-                let found_favicon_id: &str;
-                if is_file_in_root(root_path, "favicon.png") {
-                    found_favicon_id = "favicon.ico";
+                let found_favicon_id = if is_file_in_root(root_path, "favicon.ico") {
+                    "favicon.ico"
                 } else if is_file_in_root(root_path, "favicon.svg") {
-                    found_favicon_id = "favicon.svg";
+                    "favicon.svg"
                 } else if is_file_in_root(root_path, "favicon.png") {
-                    found_favicon_id = "favicon.png";
+                    "favicon.png"
                 } else if is_file_in_root(root_path, "favicon.jpg") {
-                    found_favicon_id = "favicon.jpg";
+                    "favicon.jpg"
                 } else {
                     // Not using any favicon
                     return None;
-                }
+                };
+
                 get_favicon_path_and_type(package_name, found_favicon_id)
             }
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -260,45 +260,51 @@ fn resolve_favicon(config: &fpm::Config, favicon: Option<String>) -> Option<Stri
     // favicon image path from fpm.package if provided
     let fav_path = favicon;
     let package_name = config.package.name.as_str();
-    let mut full_fav_path: String = String::new();
-    let mut fav_mime_content_type: String = String::new();
+    // let mut full_fav_path: String = String::new();
+    // let mut fav_mime_content_type: String = String::new();
 
-    match fav_path {
-        Some(ref path) => {
-            // In this case, favicon is provided with fpm.package in FPM.ftd
-            (full_fav_path, fav_mime_content_type) = get_favicon_path_and_type(package_name, path);
-        }
-        None => {
-            // If favicon not provided so we will look for favicon in the package directory
-            // By default if any file favicon.* is present we will use that file instead
-            // In case of favicon.* conflict priority will be: .ico > .svg > .png > .jpg.
-
-            // Default searching directory being the root folder of the package
-            let root_path = config.root.as_str();
-            let ico_favicon = camino::Utf8PathBuf::from(root_path.to_string()).join("favicon.ico");
-            let svg_favicon = camino::Utf8PathBuf::from(root_path.to_string()).join("favicon.svg");
-            let png_favicon = camino::Utf8PathBuf::from(root_path.to_string()).join("favicon.png");
-            let jpg_favicon = camino::Utf8PathBuf::from(root_path.to_string()).join("favicon.jpg");
-
-            // Just check if any favicon exists in the root package directory
-            // in the above mentioned priority order
-            let fav_path: &str;
-            if ico_favicon.exists() {
-                fav_path = "favicon.ico";
-            } else if svg_favicon.exists() {
-                fav_path = "favicon.svg";
-            } else if png_favicon.exists() {
-                fav_path = "favicon.png";
-            } else if jpg_favicon.exists() {
-                fav_path = "favicon.jpg";
-            } else {
-                // Not using any favicon
-                return None;
+    let (full_fav_path, fav_mime_content_type): (String, String) = {
+        match fav_path {
+            Some(ref path) => {
+                // In this case, favicon is provided with fpm.package in FPM.ftd
+                get_favicon_path_and_type(package_name, path)
             }
-            (full_fav_path, fav_mime_content_type) =
-                get_favicon_path_and_type(package_name, fav_path);
+            None => {
+                // If favicon not provided so we will look for favicon in the package directory
+                // By default if any file favicon.* is present we will use that file instead
+                // In case of favicon.* conflict priority will be: .ico > .svg > .png > .jpg.
+
+                // Default searching directory being the root folder of the package
+                let root_path = config.root.as_str();
+                let ico_favicon =
+                    camino::Utf8PathBuf::from(root_path.to_string()).join("favicon.ico");
+                let svg_favicon =
+                    camino::Utf8PathBuf::from(root_path.to_string()).join("favicon.svg");
+                let png_favicon =
+                    camino::Utf8PathBuf::from(root_path.to_string()).join("favicon.png");
+                let jpg_favicon =
+                    camino::Utf8PathBuf::from(root_path.to_string()).join("favicon.jpg");
+
+                // Just check if any favicon exists in the root package directory
+                // in the above mentioned priority order
+                let fav_path: &str;
+                if ico_favicon.exists() {
+                    fav_path = "favicon.ico";
+                } else if svg_favicon.exists() {
+                    fav_path = "favicon.svg";
+                } else if png_favicon.exists() {
+                    fav_path = "favicon.png";
+                } else if jpg_favicon.exists() {
+                    fav_path = "favicon.jpg";
+                } else {
+                    // Not using any favicon
+                    return None;
+                }
+                get_favicon_path_and_type(package_name, fav_path)
+            }
         }
-    }
+    };
+
     // Will use some favicon
     Some(favicon_html(&full_fav_path, &fav_mime_content_type))
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -238,6 +238,7 @@ pub(crate) fn id_to_path(id: &str) -> String {
 /// (if favicon is passed as header in fpm.package or if any favicon.* file is present in the root package folder)
 /// otherwise returns None
 fn resolve_favicon(config: &fpm::Config, favicon: Option<String>) -> Option<String> {
+
     /// returns html tag for using favicon.
     fn favicon_html(favicon_path: &str, content_type: &str) -> String {
         let favicon_html = format!(
@@ -269,7 +270,7 @@ fn resolve_favicon(config: &fpm::Config, favicon: Option<String>) -> Option<Stri
             (full_fav_path, fav_mime_content_type) = get_favicon_path_and_type(package_name, path);
         }
         None => {
-            // TODO:: If favicon not provided so we will look for favicon in the package directory
+            // If favicon not provided so we will look for favicon in the package directory
             // By default if any file favicon.* is present we will use that file instead
             // In case of favicon.* conflict priority will be: .ico > .svg > .png > .jpg.
 
@@ -292,14 +293,14 @@ fn resolve_favicon(config: &fpm::Config, favicon: Option<String>) -> Option<Stri
             } else if jpg_favicon.exists() {
                 fav_path = "favicon.jpg";
             } else {
-                // Not using any favicon :(
+                // Not using any favicon
                 return None;
             }
             (full_fav_path, fav_mime_content_type) =
                 get_favicon_path_and_type(package_name, fav_path);
         }
     }
-    // Will use some favicon :)
+    // Will use some favicon
     return Some(favicon_html(&full_fav_path, &fav_mime_content_type));
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -241,7 +241,7 @@ fn resolve_favicon(config: &fpm::Config, favicon: Option<String>) -> Option<Stri
     /// returns html tag for using favicon.
     fn favicon_html(favicon_path: &str, content_type: &str) -> String {
         let favicon_html = format!(
-            "<link rel=\"shortcut icon\" href=\"{}\" type=\"{}\">",
+            "\n<link rel=\"shortcut icon\" href=\"{}\" type=\"{}\">",
             favicon_path, content_type
         );
         favicon_html
@@ -321,8 +321,9 @@ pub(crate) fn replace_markers(
     let favicon_html_tag: Option<String> = resolve_favicon(config, config.package.favicon.clone());
 
     // Add favicon tag in the final html file (if available)
-    if let Some(fav_html) = favicon_html_tag {
-        html = html.replace("__favicon_html_tag__", fav_html.as_str());
+    match favicon_html_tag {
+        Some(fav_html) => html = html.replace("__favicon_html_tag__", fav_html.as_str()),
+        None => html = html.replace("__favicon_html_tag__", ""),
     }
 
     html.replace("__ftd_doc_title__", title)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -234,6 +234,75 @@ pub(crate) fn id_to_path(id: &str) -> String {
         .replace(".md", std::path::MAIN_SEPARATOR.to_string().as_str())
 }
 
+/// returns favicon html tag as string
+/// (if favicon is passed as header in fpm.package or if any favicon.* file is present in the root package folder)
+/// otherwise returns None
+fn resolve_favicon(config: &fpm::Config, favicon: Option<String>) -> Option<String> {
+    /// returns html tag for using favicon.
+    fn favicon_html(favicon_path: &str, content_type: &str) -> String {
+        let favicon_html = format!(
+            "<link rel=\"shortcut icon\" href=\"{}\" type=\"{}\">",
+            favicon_path, content_type
+        );
+        favicon_html
+    }
+
+    /// returns favicon path with package name and its mime content type
+    fn get_favicon_path_and_type(package_name: &str, favicon_path: &str) -> (String, String) {
+        // full path of favicon with package
+        let path = camino::Utf8PathBuf::from(package_name).join(favicon_path);
+        // mime content type of the favicon
+        let content_type = mime_guess::from_path(path.as_str()).first_or_octet_stream();
+
+        (path.to_string(), content_type.to_string())
+    }
+
+    // favicon image path from fpm.package if provided
+    let fav_path = favicon;
+    let package_name = config.package.name.as_str();
+    let mut full_fav_path: String = String::new();
+    let mut fav_mime_content_type: String = String::new();
+
+    match fav_path {
+        Some(ref path) => {
+            // In this case, favicon is provided with fpm.package in FPM.ftd
+            (full_fav_path, fav_mime_content_type) = get_favicon_path_and_type(package_name, path);
+        }
+        None => {
+            // TODO:: If favicon not provided so we will look for favicon in the package directory
+            // By default if any file favicon.* is present we will use that file instead
+            // In case of favicon.* conflict priority will be: .ico > .svg > .png > .jpg.
+
+            // Default searching directory being the root folder of the package
+            let root_path = config.root.as_str();
+            let ico_favicon = camino::Utf8PathBuf::from(root_path.to_string()).join("favicon.ico");
+            let svg_favicon = camino::Utf8PathBuf::from(root_path.to_string()).join("favicon.svg");
+            let png_favicon = camino::Utf8PathBuf::from(root_path.to_string()).join("favicon.png");
+            let jpg_favicon = camino::Utf8PathBuf::from(root_path.to_string()).join("favicon.jpg");
+
+            // Just check if any favicon exists in the root package directory
+            // in the above mentioned priority order
+            let fav_path: &str;
+            if ico_favicon.exists() {
+                fav_path = "favicon.ico";
+            } else if svg_favicon.exists() {
+                fav_path = "favicon.svg";
+            } else if png_favicon.exists() {
+                fav_path = "favicon.png";
+            } else if jpg_favicon.exists() {
+                fav_path = "favicon.jpg";
+            } else {
+                // Not using any favicon :(
+                return None;
+            }
+            (full_fav_path, fav_mime_content_type) =
+                get_favicon_path_and_type(package_name, fav_path);
+        }
+    }
+    // Will use some favicon :)
+    return Some(favicon_html(&full_fav_path, &fav_mime_content_type));
+}
+
 pub(crate) fn replace_markers(
     s: &str,
     config: &fpm::Config,
@@ -242,7 +311,15 @@ pub(crate) fn replace_markers(
     base_url: &str,
     main_rt: &ftd::Document,
 ) -> String {
-    s.replace("__ftd_doc_title__", title)
+    let mut html = s.to_string();
+    let favicon_html_tag: Option<String> = resolve_favicon(config, config.package.favicon.clone());
+
+    // Add favicon tag in the final html file (if available)
+    if let Some(fav_html) = favicon_html_tag {
+        html = html.replace("__favicon_html_tag__", fav_html.as_str());
+    }
+
+    html.replace("__ftd_doc_title__", title)
         .replace(
             "__ftd_canonical_url__",
             config.package.generate_canonical_url(main_id).as_str(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -238,7 +238,6 @@ pub(crate) fn id_to_path(id: &str) -> String {
 /// (if favicon is passed as header in fpm.package or if any favicon.* file is present in the root package folder)
 /// otherwise returns None
 fn resolve_favicon(config: &fpm::Config, favicon: Option<String>) -> Option<String> {
-
     /// returns html tag for using favicon.
     fn favicon_html(favicon_path: &str, content_type: &str) -> String {
         let favicon_html = format!(
@@ -301,7 +300,7 @@ fn resolve_favicon(config: &fpm::Config, favicon: Option<String>) -> Option<Stri
         }
     }
     // Will use some favicon
-    return Some(favicon_html(&full_fav_path, &fav_mime_content_type));
+    Some(favicon_html(&full_fav_path, &fav_mime_content_type))
 }
 
 pub(crate) fn replace_markers(


### PR DESCRIPTION
Made changes to use favicon on webpages

- To use favicon either include favicon.* file in the root package folder 
- or use favicon header under fpm.package and provide path to the favicon file relative to the package folder.
- refer issue for more details - https://github.com/FifthTry/fpm/issues/246

[Doc PR](https://github.com/FifthTry/fpm.dev/pull/47)