### PR TITLE
Fixed: HTML optimisation via reducing html size

### DIFF
--- a/ftd/editor.ftd
+++ b/ftd/editor.ftd
@@ -1,8 +1,16 @@
 -- import: fpm
 
+-- boolean show-create-new-folder: false
+
+-- boolean show-create-new-file: false
+
+-- boolean toc-show: true
+
+-- boolean sitemap-show: false
+
 -- boolean dialog-open: false
 
--- boolean show-tooltip: false
+\-- boolean show-tooltip: false
 
 -- boolean show-server-actions: false
 
@@ -365,11 +373,6 @@ mobile: $dialog-title-bold
 xl: $dialog-title-bold
 weight: 600
 
-
-
-
-
-
 -- ftd.font-size filename:
 line-height: 16
 size: 13
@@ -385,7 +388,32 @@ weight: 400
 
 
 
+
+
+
+
+
 -- editor:
+
+-- print-toc:
+if: $toc-show
+toc: $fs
+
+-- print-sitemap-toc:
+if: $sitemap-show
+sample-list: $sample-list
+
+-- display-rename:
+if: $show-rename
+
+-- delete-confimation:
+if: $show-delete-dialog
+
+-- new-file:
+if: $show-create-new-file
+
+-- folder:
+if: $show-create-new-folder
 
 
 
@@ -404,14 +432,24 @@ boolean show-desktop: false
 boolean show-mobile: false
 boolean show-fullscreen: false
 boolean edits: true
-boolean toc-show: true
-boolean sitemap-show: false
 background-color: $fpm.color.main.background.step-2
 color: $fpm.color.main.text-strong
+open: true
+append-at: toc-id
+
+--- overlay:
+if: $show-overlay
+
+--- container: ftd.main
+
+--- ftd.row:
+if: not $is-mobile
+width: fill
+height: fill
+id: mobile-side
 
 --- ftd.column:
-if: not $is-mobile
-id: mobile-side
+id: desktop-container
 width: percent 0
 width if not $open: percent 25
 min-width if not $open: 300
@@ -447,18 +485,15 @@ $on-click$: message-host $sync-obj
 --- ftd.image:
 src: $refresh
 
---- container:  mobile-side
+--- container: desktop-container
 
 --- ftd.column:
 width: fill
 height: fill
 spacing: 8
 overflow-y: auto
-/padding-left if not $open: 12
-/padding-right if not $open: 12
-/padding-top: 12
-id: list-container
-
+id:toc-id
+ 
 --- ftd.row:
 id: text-container
 width: fill
@@ -497,406 +532,19 @@ role: $fine-print-bold
 width: fill
 align: center
 
---- container: list-container
-
---- print-toc:
-if: $toc-show
-toc: $fs
-
---- container: list-container
-
---- print-sitemap-toc:
-if: $sitemap-show
-sample-list: $sample-list
-
---- container: ftd.main
-
---- ftd.column:
-if: $is-mobile
-width: percent 0
-width if $open: percent 100
-id: mobile-frame
-
---- ftd.column:
-if: $open
-width: percent 90
-anchor: window
-background-color: $fpm.color.main.background.base
-height: fill
-id: right-side
+--- container: toc-id
 
 --- ftd.row:
-background-color: $grey-dark
-padding-vertical: $fpm.space.space-3
-padding-horizontal: $fpm.space.space-3
+id: toc-id
 width: fill
 
---- ftd.text: $fpm.package-name
-role: $copy-print-bold
-color: $fpm.color.main.text-strong
+--- container: mobile-side
+
+--- ftd.row:
+id: left-side
 width: percent 75
-
---- ftd.row:
-spacing: 12
-align: right
-
---- ftd.image:
-src: $sync-img
-$on-click$: message-host $sync-obj
-
---- ftd.image:
-src: $refresh
-
---- ftd.column:
-anchor: window
-right: 0
-top: 0
-height: fill
-background-color: $fpm.color.main.background.step-1
-width: 53
-padding-top: 20
-padding-left: 20
-
---- ftd.image:
-src: $showbar
-width: 20
-height: auto
-$on-click$: toggle $open
-$on-click$: $show-fullscreen = true 
-
---- container:  right-side
-
---- ftd.row:
-id: text-container
-width: fill
- 
---- ftd.row:
-width: fill
-$on-click$: $toc-show= true
-$on-click$: $sitemap-show= false
-background-color if $sitemap-show: $fpm.color.main.background.step-1
-border-bottom if $sitemap-show: 1
-border-color if $sitemap-show: $fpm.color.main.border-strong
-padding-vertical: 8
-padding-horizontal: 16
-
---- ftd.text: All files
-color: $folder-color
-role: $fine-print-bold
-width: fill
-align: center
-
---- container: text-container
-
---- ftd.row:
-width: fill
-$on-click$: $toc-show= false
-$on-click$: $sitemap-show= true
-background-color if $toc-show: $fpm.color.main.background.step-1
-border-bottom if $toc-show: 1
-border-color if $toc-show: $fpm.color.main.border-strong
-padding-vertical: 8
-padding-horizontal: 16
-
---- ftd.text: Sitemap
-color: $folder-color
-role: $fine-print-bold
-width: fill
-align: center
-
---- container: right-side
-
---- print-toc:
-if: $toc-show
-toc: $fs
-
---- container: right-side
-
---- print-sitemap-toc:
-if: $sitemap-show
-sample-list: $sample-list
-
---- container: ftd.main
-
---- ftd.row:
-if: $is-mobile
-id: left-side
-width if not $is-mobile: percent 75
-width if $open: percent 100
-width if not $open: percent 100
-width if $is-mobile: fill
-width if $show-fullscreen: fill
-height: fill
-background-color: $fpm.color.main.background.base
-
---- ftd.column:
-width: fill
-id: switch-container
-spacing: 14
-
---- ftd.row:
-width: fill
-id: show-container
-spacing: 18
-padding-vertical: 12
-padding-left: 16
-
---- ftd.image:
-src: $showbar
-width: 20
-height: auto
-$on-click$: toggle $open
-
---- container: show-container
-
---- ftd.row:
-spacing: 8
-
---- ftd.text: $path
-role: $fine-print-bold
-color: $fpm.color.main.cta-primary.base
-
-\--- ftd.text: (Preview)
-role: $fine-print-bold
-color: $fpm.color.main.cta-primary.base
-white-space: nowrap
-
---- container: switch-container
-
---- ftd.input:
-if: $edits
-width: fill
-padding-horizontal: 16
-min-width: percent 100
-min-height: calc 100vh - 82px
-multiline: true
-placeholder: -- ftd.text: hello world
-value: $source
-$on-input$: $source=$VALUE
-$on-input$: message-host $edit-obj
-color: $fpm.color.main.text
-background-color: $fpm.color.main.background.base
-white-space: pre
-
---- container: switch-container
-
---- ftd.column:
-if: $show-desktop
-width: fill
-height: fill
-background-color: $fpm.color.main.text-strong
-
---- ftd.iframe:
-src: $path
-width: fill
-min-width: percent 100
-min-height: calc 100vh - 82px
-background-color: $fpm.color.main.text-strong
-
---- container: switch-container
-
---- ftd.row:
-if: $show-mobile
-width: fill
-id: mobile-container
-align: center
-
-\--- ftd.column:
-align: center
-width: 305
-height: 620
-background-image: $mobile-frame
-background-repeat: false
-
-\--- ftd.column:
-anchor: parent
-left: 21
-top: 64
-width: 300
-height: 540
-
---- ftd.iframe:
-src: $path
-height: calc 100vh
-width: fill
-
---- container: mobile-container
-
---- ftd.column:
-if: not $is-mobile
-margin-left: 134
-align: center
-
---- ftd.text: iphone X
-role: $fpm.type.fine-print
-color: $fpm.color.main.cta-primary.base
-
-\--- ftd.text: Iphone SE
-role: $fpm.type.fine-print
-color: $fpm.color.main.text
-
-\--- ftd.text: Samsung Note
-role: $fpm.type.fine-print
-color: $fpm.color.main.text
-
-\--- ftd.text: Samsung Galaxy
-role: $fpm.type.fine-print
-color: $fpm.color.main.text
-
---- container: left-side
-
---- ftd.column:
-if: not $edits
-anchor: window
-background-color: $fpm.color.main.background.step-1
-right: 0
-bottom: 0
-width: 46
-id: image
-padding-top: $fpm.space.space-3
-padding-bottom: 21
-padding-horizontal: 12
-spacing: 32
-
---- ftd.image:
-if: $edits
-src: $edit
-width: 20
-height: auto
-$on-click$: $show-desktop = false
-$on-click$: $show-mobile = false
-$on-click$: $edits = true
-
---- ftd.image:
-if: not $edits
-src: $edit-default
-width: 20
-height: auto
-$on-click$: $show-desktop = false
-$on-click$: $show-mobile = false
-$on-click$: $edits = true
-
---- container: image
-
---- ftd.image:
-if: not $show-mobile
-src: $mobile
-width: 20
-height: auto
-$on-click$: toggle $show-mobile
-$on-click$: $show-desktop= false
-$on-click$: $edits = false
-
---- ftd.image:
-if: $show-mobile
-src: $mobile-active
-width: 20
-height: auto
-
---- container: left-side
-
---- ftd.column:
-if: $edits
-width: 53
-height: fill
-padding-top: 16
-padding-bottom: 21
-id: main-sidebar
-background-color: $fpm.color.main.background.step-1
-margin-left: 16
-
---- ftd.column:
-width: fill
-height: fill
-spacing: 12
-id: sidebar
-
---- ftd.image:
-src: $m-default
-align: center
-width: fill
-height: auto
-
---- container: sidebar
-
---- ftd.image:
-src: $e-default
-align: center
-width: fill
-height: auto
-
---- container: main-sidebar
-
---- ftd.column:
-width: fill
-id: image
-padding-horizontal:  12
-spacing: 32
-
---- ftd.image:
-if: $edits
-src: $edit
-width: 20
-height: auto
-$on-click$: $show-desktop = false
-$on-click$: $show-mobile = false
-$on-click$: $edits = true
-
---- ftd.image:
-if: not $edits
-src: $edit-default
-width: 20
-height: auto
-$on-click$: $show-desktop = false
-$on-click$: $show-mobile = false
-$on-click$: $edits = true
-
---- container: image
-
---- ftd.image:
-if: not $show-mobile
-src: $mobile
-width: 20
-height: auto
-$on-click$: toggle $show-mobile
-$on-click$: $show-desktop= false
-$on-click$: $edits = false
-
---- ftd.image:
-if: $show-mobile
-src: $mobile-active
-width: 20
-height: auto
-
---- container: image
-
---- ftd.column:
-if: not $is-mobile
-
---- ftd.image:
-if: not $show-desktop
-src: $desktop
-width: 20
-height: auto
-$on-click$: toggle $show-desktop
-$on-click$: $show-mobile = false
-$on-click$: $edits = false
-
---- ftd.image:
-if: $show-desktop
-src: $desktop-active
-width: 20
-height: auto
-
---- container: ftd.main
-
---- ftd.row:
-if: not $is-mobile
-id: left-side
-width if not $is-mobile: percent 75
 width if $open: percent 100
 width if not $open: percent 75
-width if $is-mobile: fill
 height: fill
 background-color: $fpm.color.main.background.base
 
@@ -1116,6 +764,350 @@ src: $desktop-active
 width: 20
 height: auto
 
+--- container: ftd.main
+
+--- ftd.column:
+if: $is-mobile
+id: good
+height: fill
+width: fill
+
+--- ftd.column:
+width: percent 0
+width if $open: percent 100
+id: mobile-frame
+
+--- ftd.column:
+if: $open
+width: percent 90
+anchor: window
+background-color: $fpm.color.main.background.base
+height: fill
+id: right-side
+
+--- ftd.row:
+background-color: $grey-dark
+padding-vertical: $fpm.space.space-3
+padding-horizontal: $fpm.space.space-3
+width: fill
+
+--- ftd.text: $fpm.package-name
+role: $copy-print-bold
+color: $fpm.color.main.text-strong
+width: percent 75
+
+--- ftd.row:
+spacing: 12
+align: right
+
+--- ftd.image:
+src: $sync-img
+$on-click$: message-host $sync-obj
+
+--- ftd.image:
+src: $refresh
+
+--- ftd.column:
+anchor: window
+right: 0
+top: 0
+height: fill
+background-color: $fpm.color.main.background.step-1
+width: 53
+padding-top: 20
+padding-left: 20
+
+--- ftd.image:
+src: $showbar
+width: 20
+height: auto
+$on-click$: toggle $open
+$on-click$: $show-fullscreen = true 
+
+--- container:  right-side
+
+--- ftd.column:
+width: fill
+height: fill
+spacing: 8
+overflow-y: auto
+id:toc-id
+
+--- ftd.row:
+id: text-container
+width: fill
+ 
+--- ftd.row:
+width: fill
+$on-click$: $toc-show= true
+$on-click$: $sitemap-show= false
+background-color if $sitemap-show: $fpm.color.main.background.step-1
+border-bottom if $sitemap-show: 1
+border-color if $sitemap-show: $fpm.color.main.border-strong
+padding-vertical: 8
+padding-horizontal: 16
+
+--- ftd.text: All files
+color: $folder-color
+role: $fine-print-bold
+width: fill
+align: center
+
+--- container: text-container
+
+--- ftd.row:
+width: fill
+$on-click$: $toc-show= false
+$on-click$: $sitemap-show= true
+background-color if $toc-show: $fpm.color.main.background.step-1
+border-bottom if $toc-show: 1
+border-color if $toc-show: $fpm.color.main.border-strong
+padding-vertical: 8
+padding-horizontal: 16
+
+--- ftd.text: Sitemap
+color: $folder-color
+role: $fine-print-bold
+width: fill
+align: center
+
+--- ftd.row:
+id: toc-id
+width: fill
+
+--- container: good
+
+--- ftd.row:
+id: left-side
+width if $open: percent 100
+width if not $open: percent 100
+width: fill
+height: fill
+background-color: $fpm.color.main.background.base
+
+--- ftd.column:
+width: fill
+id: switch-container
+spacing: 14
+
+--- ftd.row:
+width: fill
+id: show-container
+spacing: 18
+padding-vertical: 12
+padding-left: 16
+
+--- ftd.image:
+src: $showbar
+width: 20
+height: auto
+$on-click$: toggle $open
+
+--- container: show-container
+
+--- ftd.row:
+spacing: 8
+
+--- ftd.text: $path
+role: $fine-print-bold
+color: $fpm.color.main.cta-primary.base
+
+\--- ftd.text: (Preview)
+role: $fine-print-bold
+color: $fpm.color.main.cta-primary.base
+white-space: nowrap
+
+--- container: switch-container
+
+--- ftd.input:
+if: $edits
+width: fill
+padding-horizontal: 16
+min-width: percent 100
+min-height: calc 100vh - 82px
+multiline: true
+placeholder: -- ftd.text: hello world
+value: $source
+$on-input$: $source=$VALUE
+$on-input$: message-host $edit-obj
+color: $fpm.color.main.text
+background-color: $fpm.color.main.background.base
+white-space: pre
+
+--- container: switch-container
+
+--- ftd.column:
+if: $show-desktop
+width: fill
+height: fill
+background-color: $fpm.color.main.text-strong
+
+--- ftd.iframe:
+src: $path
+width: fill
+min-width: percent 100
+min-height: calc 100vh - 82px
+background-color: $fpm.color.main.text-strong
+
+--- container: switch-container
+
+--- ftd.row:
+if: $show-mobile
+width: fill
+id: mobile-container
+align: center
+
+
+--- ftd.iframe:
+src: $path
+height: calc 100vh
+width: fill
+
+--- container: mobile-container
+
+--- ftd.column:
+if: not $is-mobile
+margin-left: 134
+align: center
+
+--- ftd.text: iphone X
+role: $fpm.type.fine-print
+color: $fpm.color.main.cta-primary.base
+
+\--- ftd.text: Iphone SE
+role: $fpm.type.fine-print
+color: $fpm.color.main.text
+
+\--- ftd.text: Samsung Note
+role: $fpm.type.fine-print
+color: $fpm.color.main.text
+
+\--- ftd.text: Samsung Galaxy
+role: $fpm.type.fine-print
+color: $fpm.color.main.text
+
+--- container: left-side
+
+--- ftd.column:
+if: not $edits
+anchor: window
+background-color: $fpm.color.main.background.step-1
+right: 0
+bottom: 0
+width: 46
+id: image
+padding-top: $fpm.space.space-3
+padding-bottom: 21
+padding-horizontal: 12
+spacing: 32
+
+--- ftd.image:
+if: $edits
+src: $edit
+width: 20
+height: auto
+$on-click$: $show-mobile = false
+$on-click$: $edits = true
+
+--- ftd.image:
+if: not $edits
+src: $edit-default
+width: 20
+height: auto
+$on-click$: $show-mobile = false
+$on-click$: $edits = true
+
+--- container: image
+
+--- ftd.image:
+if: not $show-mobile
+src: $mobile
+width: 20
+height: auto
+$on-click$: toggle $show-mobile
+$on-click$: $edits = false
+
+--- ftd.image:
+if: $show-mobile
+src: $mobile-active
+width: 20
+height: auto
+
+--- container: left-side
+
+--- ftd.column:
+if: $edits
+width: 53
+height: fill
+padding-top: 16
+padding-bottom: 21
+id: main-sidebar
+background-color: $fpm.color.main.background.step-1
+margin-left: 16
+
+--- ftd.column:
+width: fill
+height: fill
+spacing: 12
+id: sidebar
+
+--- ftd.image:
+src: $m-default
+align: center
+width: fill
+height: auto
+
+--- container: sidebar
+
+--- ftd.image:
+src: $e-default
+align: center
+width: fill
+height: auto
+
+--- container: main-sidebar
+
+--- ftd.column:
+width: fill
+id: image
+padding-horizontal:  12
+spacing: 32
+
+--- ftd.image:
+if: $edits
+src: $edit
+width: 20
+height: auto
+$on-click$: $show-mobile = false
+$on-click$: $edits = true
+
+--- ftd.image:
+if: not $edits
+src: $edit-default
+width: 20
+height: auto
+$on-click$: $show-mobile = false
+$on-click$: $edits = true
+
+--- container: image
+
+--- ftd.image:
+if: not $show-mobile
+src: $mobile
+width: 20
+height: auto
+$on-click$: toggle $show-mobile
+$on-click$: $show-desktop= false
+$on-click$: $edits = false
+
+--- ftd.image:
+if: $show-mobile
+src: $mobile-active
+width: 20
+height: auto
+
+--- container: ftd.main
+
 
 
 
@@ -1268,19 +1260,7 @@ data: $new-name
 
 -- ftd.column print-toc:
 fpm.toc-item list toc:
-boolean open: true
 width: fill
-
---- ftd.row:
-width: fill
-spacing: 4
-id: all-files-container
-
---- container: ftd.main
-
---- ftd.column:
-width: fill
-if: $open
 margin-top if $is-mobile: $fpm.space.space-2
 
 --- print-toc-item:
@@ -1297,203 +1277,7 @@ is-first: true
 
 
 
--- optional string revert-file-path:
-$always-include$: true
-
--- object revert-obj:
-function: post
-url: -/revert/
-path: $revert-file-path
-operation: delete
-
-
-
-
-
-
-
-
-
-
--- ftd.column print-toc-item:
-fpm.toc-item toc:
-boolean is-first: false
-boolean show-actions: false
-boolean show-rename: false
-boolean show-create-new-file: false
-boolean show-create-new-folder: false
-boolean show: false
-width: fill
-border-radius: 2
-padding-bottom: 2
-padding-top: 2
-boolean show-children: false
-id: file-row
-
---- overlay:
-if: $show-overlay
-
---- delete-confimation:
-if: $show-delete-dialog
-file: $toc.path
-
---- container: ftd.main
-
---- ftd.row:
-if: $show-rename
-anchor: window
-width: 285
-height: 30
-left: 370
-left if $is-mobile: 12
-top: 84
-z-index: 10000
-background-color: $fpm.color.main.background.step-2
-border-radius: 4
-id: rename-row
-
---- ftd.row:
-width: fill
-background-color: $fpm.color.main.background.step-2
-padding-left: 10 
-padding-right: 5
-padding-vertical: 3
-border-radius: 4
-
---- ftd.text: Rename
-role: $tiny
-color: $fpm.color.main.cta-primary.base
-margin-right: $fpm.space.space-2
-align: center
-
---- ftd.row:
-width: fill
-background-color: $fpm.color.main.background.step-1
-
---- ftd.input:
-width: fill
-value: $toc.title
-$on-input$: $new-name=$VALUE
-$on-input$: $rename-file-path=$toc.path
-padding-horizontal: 10
-padding-vertical: $fpm.space.space-2
-background-color: $fpm.color.main.background.step-1
-color: $fpm.color.main.text-strong
-border-width: 0
-cursor: text
-
---- ftd.image: 
-src: $arrow-right
-$on-click$: message-host $rename-obj
-align: center
-margin-right: 10
-
-/--- ftd.text: Revert
-background-color: $red
-color: $fpm.color.main.text-strong
-padding-horizontal: 2
-if: $show-revert
-$on-click$: $revert-file-path=$toc.path
-$on-click$: message-host $revert-obj
-
---- ftd.row:
-anchor: parent
-right: -12
-top: -12
-z-index: 9999
-width: 16
-height: 16
-background-color: $fpm.color.main.background.step-2
-border-width: 1
-border-color: $grey-dark
-padding: 3
-border-radius: 100
-id: close
-
---- ftd.image:
-src: $close
-width: 8
-height: 8
-$on-click$: $show-rename = false
-$on-click$: $dialog-open = false
-
---- container: ftd.main
-
---- ftd.row:
-if: $show-create-new-file
-anchor: window
-width: 285
-height: 30
-left: 370
-left if $is-mobile: 12
-top: 84
-z-index: 10000
-background-color: $fpm.color.main.background.step-2
-border-radius: 4
-id: newfile-row
-
---- ftd.row:
-width: fill
-background-color: $fpm.color.main.background.step-2
-padding-left: 10 
-padding-right: 5
-padding-vertical: 3
-border-radius: 4
-
---- ftd.text: New file
-role: $tiny
-color: $fpm.color.main.cta-primary.base
-margin-right: $fpm.space.space-2
-align: center
-white-space: nowrap
-
---- ftd.row:
-width: fill
-background-color: $fpm.color.main.background.step-1
-
---- ftd.input:
-width: fill
-placeholder: filename.ftd
-$on-input$: $create-file-path=$VALUE
-padding-horizontal: 10
-padding-vertical: $fpm.space.space-2
-background-color: $fpm.color.main.background.step-1
-color: $fpm.color.main.text-strong
-border-width: 0
-cursor: text
-
---- ftd.image: 
-src: $arrow-right
-$on-click$: message-host $create-obj
-align: center
-margin-right: 10
-
---- ftd.row:
-anchor: parent
-right: -12
-top: -12
-z-index: 9999
-width: 16
-height: 16
-background-color: $fpm.color.main.background.step-2
-border-width: 1
-border-color: $grey-dark
-padding: 3
-border-radius: 100
-id: close
-
---- ftd.image:
-src: $close
-width: 8
-height: 8
-$on-click$: $show-create-new-file = false
-$on-click$: $dialog-open = false
-$on-click$: $show-overlay = false
-
---- container: ftd.main
-
---- ftd.row:
-if: $show-create-new-folder
+-- ftd.row folder:
 anchor: window
 width: 285
 height: 30
@@ -1563,7 +1347,122 @@ $on-click$: $show-create-new-folder = false
 $on-click$: $dialog-open = false
 $on-click$: $show-overlay = false
 
---- container: ftd.main
+
+
+
+
+
+
+
+
+
+-- optional string revert-file-path:
+$always-include$: true
+
+-- object revert-obj:
+function: post
+url: -/revert/
+path: $revert-file-path
+operation: delete
+
+
+
+
+
+
+
+
+
+
+-- ftd.row new-file:
+anchor: window
+width: 285
+height: 30
+left: 370
+left if $is-mobile: 12
+top: 84
+z-index: 10000
+background-color: $fpm.color.main.background.step-2
+border-radius: 4
+id: newfile-row
+
+--- ftd.row:
+width: fill
+background-color: $fpm.color.main.background.step-2
+padding-left: 10 
+padding-right: 5
+padding-vertical: 3
+border-radius: 4
+
+--- ftd.text: New file
+role: $tiny
+color: $fpm.color.main.cta-primary.base
+margin-right: $fpm.space.space-2
+align: center
+white-space: nowrap
+
+--- ftd.row:
+width: fill
+background-color: $fpm.color.main.background.step-1
+
+--- ftd.input:
+width: fill
+placeholder: filename.ftd
+$on-input$: $create-file-path=$VALUE
+padding-horizontal: 10
+padding-vertical: $fpm.space.space-2
+background-color: $fpm.color.main.background.step-1
+color: $fpm.color.main.text-strong
+border-width: 0
+cursor: text
+
+--- ftd.image: 
+src: $arrow-right
+$on-click$: message-host $create-obj
+align: center
+margin-right: 10
+
+--- ftd.row:
+anchor: parent
+right: -12
+top: -12
+z-index: 9999
+width: 16
+height: 16
+background-color: $fpm.color.main.background.step-2
+border-width: 1
+border-color: $grey-dark
+padding: 3
+border-radius: 100
+id: close
+
+--- ftd.image:
+src: $close
+width: 8
+height: 8
+$on-click$: $show-create-new-file = false
+$on-click$: $dialog-open = false
+$on-click$: $show-overlay = false
+
+
+
+
+
+
+
+
+
+
+-- ftd.column print-toc-item:
+fpm.toc-item toc:
+boolean is-first: false
+boolean show-actions: false
+boolean show: false
+width: fill
+border-radius: 2
+padding-bottom: 2
+padding-top: 2
+boolean show-children: false
 
 --- ftd.row:
 $on-click$: toggle $show-children
@@ -1627,6 +1526,8 @@ if: not $dialog-open
 src: $rename-icon
 width: 24
 if: not $show
+$on-click$: $rename-path = $toc.path
+$on-click$: $rename-title = $toc.title
 $on-click$: $show-rename = true
 $on-click$: $dialog-open = true
 id: rename-area
@@ -1713,6 +1614,100 @@ $loop$: $toc.children as $obj
 toc: $obj
 
 --- container: ftd.main
+
+
+
+
+
+
+
+
+
+
+-- optional string rename-path:
+$always-include$: true
+
+-- optional string rename-title:
+$always-include$: true
+
+
+
+
+
+
+
+
+
+
+-- ftd.row display-rename:
+anchor: window
+width: 285
+height: 30
+left: 370
+left if $is-mobile: 12
+top: 84
+z-index: 10000
+background-color: $fpm.color.main.background.step-2
+border-radius: 4
+id: rename-row
+
+--- ftd.row:
+width: fill
+background-color: $fpm.color.main.background.step-2
+padding-left: 10
+padding-right: 5
+padding-vertical: 3
+border-radius: 4
+
+--- ftd.text: Rename
+role: $tiny
+color: $fpm.color.main.cta-primary.base
+margin-right: $fpm.space.space-2
+align: center
+
+--- ftd.row:
+width: fill
+background-color: $fpm.color.main.background.step-1
+
+--- ftd.input:
+width: fill
+value: $rename-title
+placeholder: $rename-title
+$on-input$: $new-name=$VALUE
+$on-input$: $rename-file-path=$rename-path
+padding-horizontal: 10
+padding-vertical: $fpm.space.space-2
+background-color: $fpm.color.main.background.step-1
+color: $fpm.color.main.text-strong
+border-width: 0
+cursor: text
+
+--- ftd.image:
+src: $arrow-right
+$on-click$: message-host $rename-obj
+align: center
+margin-right: 10
+
+--- ftd.row:
+anchor: parent
+right: -12
+top: -12
+z-index: 9999
+width: 16
+height: 16
+background-color: $fpm.color.main.background.step-2
+border-width: 1
+border-color: $grey-dark
+padding: 3
+border-radius: 100
+id: close
+
+--- ftd.image:
+src: $close
+width: 8
+height: 8
+$on-click$: $show-rename = false
+$on-click$: $dialog-open = false
 
 
 
@@ -1990,7 +1985,8 @@ height: fill
 anchor: window
 top: 0
 left: 0
-z-index: 99
+z-index: 9999
+id: iamoverlay
 
 
 
@@ -2025,13 +2021,12 @@ caption title: Delete file?
 string subtitle: This file has changes which will be  lost
 string close: CANCEL DELETE
 string confirm: CONFIRM DELETE
-string file: 
 width: percent 80
 width if $is-mobile: fill
 height: 365
 max-width: 500
 align: center
-background-color: $fpm.color.main.cta-tertiary.pressed
+background-color: $delete-dialog-bg
 padding-horizontal: $fpm.space.space-4
 padding-vertical: $fpm.space.space-4
 border-radius: 8
@@ -2069,7 +2064,7 @@ multiline: true
 placeholder: -- ftd.text: hello world
 value: $source
 $on-input$: $source=$VALUE
-$on-input$: message-host $delete-obj
+$on-input$: message-host $edit-obj
 background-color: $code-bg
 color: $fpm.color.main.text
 white-space: pre
@@ -2089,15 +2084,15 @@ role: $dialog-title
 color: $fpm.color.main.text
 $on-click$: $show-delete-dialog = false
 $on-click$: $show-overlay = false
-$on-click$: $show-rename = false
 $on-click$: $dialog-open = false
 
 --- ftd.text: $confirm
 role: $dialog-title
 color: $orange
-$on-click$: $delete-file-path=$file
-$on-click$: message-host $delete-obj
 $on-click$: $show-overlay = false
+$on-click$: $dialog-open = false
+$on-click$: $show-delete-dialog = false
+$on-click$: message-host $delete-obj
 
 
 
@@ -2161,8 +2156,8 @@ light: rgba(73, 236, 70, 0.1)
 dark: rgba(73, 236, 70, 0.1)
 
 -- ftd.color overlay-bg:
-light: rgba(0, 0, 0, 0.1)
-dark: rgba(0, 0, 0, 0.1)
+light: rgba(0, 0, 0, 0.6)
+dark: rgba(0, 0, 0, 0.6)
 
 -- ftd.color code-bg:
 light: rgba(44, 48, 58, 1)
@@ -2181,7 +2176,6 @@ dark: rgba(44, 48, 58, 1)
 fpm.toc-item list sample-list:
 width: fill
 margin-top if $is-mobile: $fpm.space.space-2
-
 
 --- print-sitemap-toc-item:
 $loop$: $sample-list as $obj
@@ -2203,7 +2197,6 @@ caption title:
 optional string url:
 fpm.toc-item list children:
 boolean show-actions: false
-boolean show-rename: false
 boolean show-tooltip: false
 boolean show: false
 width: fill
@@ -2261,7 +2254,9 @@ padding-right: $fpm.space.space-1
 width: fill
 
 --- show-sample-item: $title
+show-tooltip: $show-tooltip
 link: $url
+
 
 --- container: ftd.main
 
@@ -2288,11 +2283,13 @@ url: $obj.url
 
 
 -- ftd.row show-sample-item:
+boolean show-tooltip: false
 caption title:
 optional string link:
 padding-horizontal: 2
 width: fill
-boolean show-tooltip: false
+open: true
+append-at: sample-item-container
 
 --- ftd.row:
 width: fill
@@ -2320,13 +2317,34 @@ padding-horizontal: $fpm.space.space-1
 border-radius: 100
 margin-top: 4
 background-color: $fpm.color.main.text
-$on-mouse-enter$: toggle $show-tooltip 
-$on-mouse-leave$: toggle $show-tooltip 
+$on-mouse-enter$: $show-tooltip = true
+$on-mouse-leave$: $show-tooltip = false
 
 --- container: sample-container
 
---- ftd.column:
+--- ftd.row:
+id: sample-item-container
+
+--- sitemap-data:
 if: $show-tooltip
+
+--- container: ftd.main
+
+--- ftd.text: A
+color: $added
+role: $status-font
+align: right
+
+
+
+
+
+
+
+
+
+
+-- ftd.column sitemap-data:
 width: fill
 id: tooltip-container
 anchor: parent
@@ -2347,7 +2365,7 @@ border-bottom: 1
 border-color: $border-line
 border-style: solid
 z-index: 999
---- container: tooltip-container
+--- container: ftd.main
 
 --- ftd.row:
 width: 120
@@ -2417,9 +2435,3 @@ color: $fpm.color.main.text-strong
 role: $small-font
 color: $fpm.color.main.text-strong
 width: fill
---- container: ftd.main
-
---- ftd.text: A
-color: $added
-role: $status-font
-align: right

--- a/ftd/editor.ftd
+++ b/ftd/editor.ftd
@@ -10,8 +10,6 @@
 
 -- boolean dialog-open: false
 
-\-- boolean show-tooltip: false
-
 -- boolean show-server-actions: false
 
 -- boolean show-datas: false

--- a/ftd/editor.ftd
+++ b/ftd/editor.ftd
@@ -1223,6 +1223,7 @@ $always-include$: true
 -- object delete-obj:
 function: http  
 method: post
+url: $url
 path: $delete-file-path
 operation: delete
 

--- a/ftd/editor.ftd
+++ b/ftd/editor.ftd
@@ -422,38 +422,6 @@ if: $show-create-new-folder
 
 
 
--- fpm.toc-item list fs:
-$processor$: package-tree
-
--- optional string source:
-$always-include$: true
-
--- optional string path:
-$always-include$: true
-
--- string url: -/edit/
-
--- object edit-obj:
-function: http
-method: post
-url: $url
-value: $source
-path: $path
-
--- optional string diff:
-$always-include$: true
-
--- boolean show-diff: false
-
-
-
-
-
-
-
-
-
-
 -- ftd.row editor:
 width: fill
 height: fill
@@ -523,7 +491,7 @@ height: fill
 spacing: 8
 overflow-y: auto
 id:toc-id
-
+ 
 --- ftd.row:
 id: text-container
 width: fill
@@ -852,7 +820,7 @@ src: $showbar
 width: 20
 height: auto
 $on-click$: toggle $open
-$on-click$: $show-fullscreen = true
+$on-click$: $show-fullscreen = true 
 
 --- container:  right-side
 
@@ -866,7 +834,7 @@ id:toc-id
 --- ftd.row:
 id: text-container
 width: fill
-
+ 
 --- ftd.row:
 width: fill
 $on-click$: $toc-show= true
@@ -1146,10 +1114,9 @@ height: auto
 
 
 
-
--- object sync-obj:
-function: http
-method: get
+-- object sync-obj: 
+function: http  
+method: get 
 url: /-/editor-sync/
 
 -- ftd.row sync:
@@ -1208,8 +1175,8 @@ $on-click$: message-host $view-obj
 -- optional string create-file-path:
 $always-include$: true
 
--- object create-obj:
-function: http
+-- object create-obj: 
+function: http  
 method: post
 url: $url
 path: $create-file-path
@@ -1254,9 +1221,8 @@ border-radius: 8
 $always-include$: true
 
 -- object delete-obj:
-function: http
+function: http  
 method: post
-url: $url
 path: $delete-file-path
 operation: delete
 
@@ -1312,132 +1278,6 @@ is-first: true
 
 
 -- ftd.row folder:
-
--- optional string revert-file-path:
-$always-include$: true
-
--- object revert-obj:
-function: http
-method: post
-url: -/revert/
-path: $revert-file-path
-operation: delete
-
-
-
-
-
-
-
-
-
-
--- ftd.column print-toc-item:
-fpm.toc-item toc:
-boolean is-first: false
-boolean show-actions: false
-boolean show-rename: false
-boolean show-create-new-file: false
-boolean show-create-new-folder: false
-boolean show: false
-width: fill
-border-radius: 2
-padding-bottom: 2
-padding-top: 2
-boolean show-children: false
-id: file-row
-
---- overlay:
-if: $show-overlay
-
---- delete-confimation:
-if: $show-delete-dialog
-file: $toc.path
-
---- container: ftd.main
-
---- ftd.row:
-if: $show-rename
-anchor: window
-width: 285
-height: 30
-left: 370
-left if $is-mobile: 12
-top: 84
-z-index: 10000
-background-color: $fpm.color.main.background.step-2
-border-radius: 4
-id: rename-row
-
---- ftd.row:
-width: fill
-background-color: $fpm.color.main.background.step-2
-padding-left: 10
-padding-right: 5
-padding-vertical: 3
-border-radius: 4
-
---- ftd.text: Rename
-role: $tiny
-color: $fpm.color.main.cta-primary.base
-margin-right: $fpm.space.space-2
-align: center
-
---- ftd.row:
-width: fill
-background-color: $fpm.color.main.background.step-1
-
---- ftd.input:
-width: fill
-value: $toc.title
-$on-input$: $new-name=$VALUE
-$on-input$: $rename-file-path=$toc.path
-padding-horizontal: 10
-padding-vertical: $fpm.space.space-2
-background-color: $fpm.color.main.background.step-1
-color: $fpm.color.main.text-strong
-border-width: 0
-cursor: text
-
---- ftd.image:
-src: $arrow-right
-$on-click$: message-host $rename-obj
-align: center
-margin-right: 10
-
-/--- ftd.text: Revert
-background-color: $red
-color: $fpm.color.main.text-strong
-padding-horizontal: 2
-if: $show-revert
-$on-click$: $revert-file-path=$toc.path
-$on-click$: message-host $revert-obj
-
---- ftd.row:
-anchor: parent
-right: -12
-top: -12
-z-index: 9999
-width: 16
-height: 16
-background-color: $fpm.color.main.background.step-2
-border-width: 1
-border-color: $grey-dark
-padding: 3
-border-radius: 100
-id: close
-
---- ftd.image:
-src: $close
-width: 8
-height: 8
-$on-click$: $show-rename = false
-$on-click$: $dialog-open = false
-
---- container: ftd.main
-
---- ftd.row:
-if: $show-create-new-file
 anchor: window
 width: 285
 height: 30
@@ -1516,13 +1356,14 @@ $on-click$: $show-overlay = false
 
 
 
--- optional string revert-file-path:
-$always-include$: true
+-- optional string revert-file-path:  
+$always-include$: true  
 
--- object revert-obj:
-function: post
-url: -/revert/
-path: $revert-file-path
+-- object revert-obj: 
+function: http  
+method: post  
+url: -/revert/  
+path: $revert-file-path 
 operation: delete
 
 


### PR DESCRIPTION
Removing below components outsize editor component helped reduce html size of editor rendered in browser:
1. Moved - New File dialog outside editor component
2. Moved - New folder dialog outside editor component
3. Moved - Rename File dialog outside editor component
4. Moved - Delete File dialog outside editor component
5. Moved - Sitemap outside editor component
6. Moved - file tree toc outside editor component
Below screen-shot showing html rendered size on Chrome browser:
Before optimisation html size: 12.5mb - loading time: 5.47 seconds 
After optimised html size: 4.5mb - loading time: 1.69 seconds 
<img width="1401" alt="Screenshot 2022-07-15 at 1 09 58 PM" src="https://user-images.githubusercontent.com/68585007/179176857-f12ae059-53da-4d1a-ae52-2dd850f7fc04.png">
