### PR TITLE
document processors(`document-id`, `document-full-id`, `document-filename`, `document-suffix`)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -376,6 +376,7 @@ impl Config {
 
     pub async fn get_file_and_package_by_id(&mut self, id: &str) -> fpm::Result<fpm::File> {
         let file_name = self.get_file_path_and_resolve(id).await?;
+        dbg!(&file_name);
         let package = self.find_package_by_id(id).await?.1;
         let mut file = fpm::get_file(
             package.name.to_string(),
@@ -397,10 +398,21 @@ impl Config {
         Ok(file)
     }
 
+    pub async fn get_file_path(&self, id: &str) -> fpm::Result<String> {
+        unimplemented!()
+    }
+
+    pub fn doc_id(&self) -> Option<String> {
+        self.current_document
+            .clone()
+            .map(|v| fpm::utils::id_to_path(v.as_str()))
+            .map(|v| v.trim().replace(std::path::MAIN_SEPARATOR, "/"))
+    }
+
     pub(crate) async fn get_file_path_and_resolve(&mut self, id: &str) -> fpm::Result<String> {
         let (package_name, package) = self.find_package_by_id(id).await?;
-        let package = self.resolve_package(&package).await?;
-        self.add_package(&package);
+        //let package = self.resolve_package(&package).await?;
+        //self.add_package(&package);
         let mut id = id.to_string();
         let mut add_packages = "".to_string();
         if let Some(new_id) = id.strip_prefix("-/") {

--- a/src/config.rs
+++ b/src/config.rs
@@ -376,7 +376,6 @@ impl Config {
 
     pub async fn get_file_and_package_by_id(&mut self, id: &str) -> fpm::Result<fpm::File> {
         let file_name = self.get_file_path_and_resolve(id).await?;
-        dbg!(&file_name);
         let package = self.find_package_by_id(id).await?.1;
         let mut file = fpm::get_file(
             package.name.to_string(),
@@ -398,10 +397,6 @@ impl Config {
         Ok(file)
     }
 
-    pub async fn get_file_path(&self, id: &str) -> fpm::Result<String> {
-        unimplemented!()
-    }
-
     pub fn doc_id(&self) -> Option<String> {
         self.current_document
             .clone()
@@ -409,10 +404,42 @@ impl Config {
             .map(|v| v.trim().replace(std::path::MAIN_SEPARATOR, "/"))
     }
 
+    pub async fn get_file_path(&self, id: &str) -> fpm::Result<String> {
+        let (package_name, package) = self.find_package_by_doc_id(id).await?;
+        let mut id = id.to_string();
+        let mut add_packages = "".to_string();
+        if let Some(new_id) = id.strip_prefix("-/") {
+            // Check if the id is alias for index.ftd. eg: `/-/bar/`
+            if new_id.starts_with(&package_name) || !package.name.eq(self.package.name.as_str()) {
+                id = new_id.to_string();
+            }
+            if !package.name.eq(self.package.name.as_str()) {
+                add_packages = format!(".packages/{}/", package.name);
+            }
+        }
+        let id = {
+            let mut id = id
+                .split_once("-/")
+                .map(|(id, _)| id)
+                .unwrap_or_else(|| id.as_str())
+                .trim()
+                .trim_start_matches(package_name.as_str());
+            if id.is_empty() {
+                id = "/";
+            }
+            id
+        };
+        Ok(format!(
+            "{}{}",
+            add_packages,
+            package.resolve_by_id(id, None).await?.0
+        ))
+    }
+
     pub(crate) async fn get_file_path_and_resolve(&mut self, id: &str) -> fpm::Result<String> {
         let (package_name, package) = self.find_package_by_id(id).await?;
-        //let package = self.resolve_package(&package).await?;
-        //self.add_package(&package);
+        let package = self.resolve_package(&package).await?;
+        self.add_package(&package);
         let mut id = id.to_string();
         let mut add_packages = "".to_string();
         if let Some(new_id) = id.strip_prefix("-/") {
@@ -442,6 +469,43 @@ impl Config {
             add_packages,
             package.resolve_by_id(id, None).await?.0
         ))
+    }
+
+    /// Return (package name or alias, package)
+    /// Duplicate code with find_package_by_id: this function is updating all_packages
+    pub(crate) async fn find_package_by_doc_id(
+        &self,
+        id: &str,
+    ) -> fpm::Result<(String, fpm::Package)> {
+        let id = if let Some(id) = id.strip_prefix("-/") {
+            id
+        } else {
+            return Ok((self.package.name.to_string(), self.package.to_owned()));
+        };
+
+        if let Some(package) = self.package.aliases().iter().find_map(|(alias, d)| {
+            if id.starts_with(alias) {
+                Some((alias.to_string(), (*d).to_owned()))
+            } else {
+                None
+            }
+        }) {
+            return Ok(package);
+        }
+
+        for (package_name, package) in self.all_packages.iter() {
+            if id.starts_with(package_name) {
+                return Ok((package_name.to_string(), package.to_owned()));
+            }
+        }
+
+        if let Some(package_root) = find_root_for_file(&self.packages_root.join(id), "FPM.ftd") {
+            let mut package = fpm::Package::new("unknown-package");
+            package.resolve(&package_root.join("FPM.ftd")).await?;
+            return Ok((package.name.to_string(), package));
+        }
+
+        Ok((self.package.name.to_string(), self.package.to_owned()))
     }
 
     /// Return (package name or alias, package)

--- a/src/library/document.rs
+++ b/src/library/document.rs
@@ -70,16 +70,35 @@ pub mod processor {
                 })?;
 
         Ok(ftd::Value::String {
-            text: format!("{}", file_path.trim()),
+            text: file_path.trim().to_string(),
             source: ftd::TextSource::Default,
         })
     }
 
     pub fn document_suffix<'a>(
-        section: &ftd::p1::Section,
+        _section: &ftd::p1::Section,
         doc: &ftd::p2::TDoc<'a>,
         config: &fpm::Config,
     ) -> ftd::p1::Result<ftd::Value> {
-        unimplemented!()
+        let doc_id = config.doc_id().unwrap_or_else(|| {
+            doc.name
+                .to_string()
+                .replace(config.package.name.as_str(), "")
+        });
+
+        Ok(doc_id.split_once('/').map_or_else(
+            || ftd::Value::None {
+                kind: ftd::p2::Kind::String {
+                    caption: false,
+                    body: false,
+                    default: None,
+                    is_reference: false,
+                },
+            },
+            |(_f, s)| ftd::Value::String {
+                text: s.to_string(),
+                source: ftd::TextSource::Default,
+            },
+        ))
     }
 }

--- a/src/library/document.rs
+++ b/src/library/document.rs
@@ -86,19 +86,22 @@ pub mod processor {
                 .replace(config.package.name.as_str(), "")
         });
 
-        Ok(doc_id.split_once('/').map_or_else(
-            || ftd::Value::None {
-                kind: ftd::p2::Kind::String {
-                    caption: false,
-                    body: false,
-                    default: None,
-                    is_reference: false,
-                },
-            },
-            |(_f, s)| ftd::Value::String {
-                text: s.to_string(),
+        let value = doc_id
+            .split_once("/-/")
+            .map(|(_, y)| y.trim().to_string())
+            .map(|suffix| ftd::Value::String {
+                text: suffix,
                 source: ftd::TextSource::Default,
+            });
+
+        Ok(ftd::Value::Optional {
+            data: Box::new(value),
+            kind: ftd::p2::Kind::String {
+                caption: false,
+                body: false,
+                default: None,
+                is_reference: false,
             },
-        ))
+        })
     }
 }

--- a/src/library/document.rs
+++ b/src/library/document.rs
@@ -1,0 +1,30 @@
+pub mod processor {
+    pub fn document_id<'a>(
+        section: &ftd::p1::Section,
+        doc: &ftd::p2::TDoc<'a>,
+        config: &fpm::Config,
+    ) -> ftd::p1::Result<ftd::Value> {
+        unimplemented!()
+    }
+    pub fn document_full_id<'a>(
+        section: &ftd::p1::Section,
+        doc: &ftd::p2::TDoc<'a>,
+        config: &fpm::Config,
+    ) -> ftd::p1::Result<ftd::Value> {
+        unimplemented!()
+    }
+    pub fn document_filename<'a>(
+        section: &ftd::p1::Section,
+        doc: &ftd::p2::TDoc<'a>,
+        config: &fpm::Config,
+    ) -> ftd::p1::Result<ftd::Value> {
+        unimplemented!()
+    }
+    pub fn document_suffix<'a>(
+        section: &ftd::p1::Section,
+        doc: &ftd::p2::TDoc<'a>,
+        config: &fpm::Config,
+    ) -> ftd::p1::Result<ftd::Value> {
+        unimplemented!()
+    }
+}

--- a/src/library/document.rs
+++ b/src/library/document.rs
@@ -1,17 +1,51 @@
+/*
+document filename
+foo/abc.ftd
+
+document id
+/foo/abc/
+/foo/abc/-/x/y/ --> full id
+*/
+
 pub mod processor {
+
     pub fn document_id<'a>(
-        section: &ftd::p1::Section,
+        _section: &ftd::p1::Section,
         doc: &ftd::p2::TDoc<'a>,
         config: &fpm::Config,
     ) -> ftd::p1::Result<ftd::Value> {
-        unimplemented!()
+        let doc_id = config.doc_id().unwrap_or_else(|| {
+            doc.name
+                .to_string()
+                .replace(config.package.name.as_str(), "")
+        });
+
+        let document_id = doc_id
+            .split_once("/-/")
+            .map(|x| x.0)
+            .unwrap_or_else(|| &doc_id)
+            .trim_matches('/');
+
+        Ok(ftd::Value::String {
+            text: format!("/{}/", document_id),
+            source: ftd::TextSource::Default,
+        })
     }
     pub fn document_full_id<'a>(
-        section: &ftd::p1::Section,
+        _section: &ftd::p1::Section,
         doc: &ftd::p2::TDoc<'a>,
         config: &fpm::Config,
     ) -> ftd::p1::Result<ftd::Value> {
-        unimplemented!()
+        let full_document_id = config.doc_id().unwrap_or_else(|| {
+            doc.name
+                .to_string()
+                .replace(config.package.name.as_str(), "")
+        });
+
+        Ok(ftd::Value::String {
+            text: format!("/{}/", full_document_id.trim_matches('/')),
+            source: ftd::TextSource::Default,
+        })
     }
     pub fn document_filename<'a>(
         section: &ftd::p1::Section,

--- a/src/library/get_data.rs
+++ b/src/library/get_data.rs
@@ -3,6 +3,8 @@ pub fn processor(
     doc: &ftd::p2::TDoc,
     config: &fpm::Config,
 ) -> ftd::p1::Result<ftd::Value> {
+    dbg!(&config.current_document);
+
     let name = match section.header.string(doc.name, section.line_number, "key") {
         Ok(name) => name,
         _ => {
@@ -38,6 +40,8 @@ pub fn processor(
             })
             .trim()
             .replace(std::path::MAIN_SEPARATOR, "/");
+
+        dbg!(&doc_id);
 
         if let Some(extra_data) = sitemap.get_extra_data_by_id(doc_id.as_str()) {
             if let Some(data) = extra_data.get(name.as_str()) {

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -386,7 +386,10 @@ impl Library2 {
             "package-query" => fpm::library::sqlite::processor(section, doc, &self.config).await,
             "toc" => fpm::library::toc::processor(section, doc, &self.config),
             "include" => fpm::library::include::processor(section, doc, &self.config),
-            "get-data" => fpm::library::get_data::processor(section, doc, &self.config),
+            "get-data" => {
+                dbg!(&self.document_id);
+                fpm::library::get_data::processor(section, doc, &self.config)
+            }
             "sitemap" => fpm::library::sitemap::processor(section, doc, &self.config),
             "full-sitemap" => fpm::library::full_sitemap::processor(section, doc, &self.config),
             "user-groups" => fpm::user_group::processor::user_groups(section, doc, &self.config),

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -177,6 +177,9 @@ impl Library {
                 )
                 .await
             }
+            "document-filename" => {
+                document::processor::document_filename(section, doc, &self.config).await
+            }
             _ => process_sync(&self.config, section, self.document_id.as_str(), doc),
         }
     }
@@ -210,7 +213,6 @@ pub fn process_sync<'a>(
         "package-tree" => fpm::library::package_tree::processor_sync(section, doc, config),
         "document-id" => document::processor::document_id(section, doc, config),
         "document-full-id" => document::processor::document_full_id(section, doc, config),
-        "document-filename" => document::processor::document_filename(section, doc, config),
         "document-suffix" => document::processor::document_suffix(section, doc, config),
         t => Err(ftd::p1::Error::NotFound {
             doc_id: document_id.to_string(),
@@ -411,7 +413,7 @@ impl Library2 {
             "document-id" => document::processor::document_id(section, doc, &self.config),
             "document-full-id" => document::processor::document_full_id(section, doc, &self.config),
             "document-filename" => {
-                document::processor::document_filename(section, doc, &self.config)
+                document::processor::document_filename(section, doc, &self.config).await
             }
             "document-suffix" => document::processor::document_suffix(section, doc, &self.config),
             "package-tree" => {

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -1,3 +1,4 @@
+mod document;
 mod fetch_file;
 mod fpm_dot_ftd;
 pub(crate) mod full_sitemap;
@@ -207,6 +208,10 @@ pub fn process_sync<'a>(
         "package-query" => fpm::library::sqlite::processor_(section, doc, config),
         "fetch-file" => fpm::library::fetch_file::processor_sync(section, doc, config),
         "package-tree" => fpm::library::package_tree::processor_sync(section, doc, config),
+        "document-id" => document::processor::document_id(section, doc, config),
+        "document-full-id" => document::processor::document_full_id(section, doc, config),
+        "document-filename" => document::processor::document_filename(section, doc, config),
+        "document-suffix" => document::processor::document_suffix(section, doc, config),
         t => Err(ftd::p1::Error::NotFound {
             doc_id: document_id.to_string(),
             line_number: section.line_number,

--- a/src/library/mod.rs
+++ b/src/library/mod.rs
@@ -405,6 +405,12 @@ impl Library2 {
             "user-group-by-id" => {
                 fpm::user_group::processor::user_group_by_id(section, doc, &self.config)
             }
+            "document-id" => document::processor::document_id(section, doc, &self.config),
+            "document-full-id" => document::processor::document_full_id(section, doc, &self.config),
+            "document-filename" => {
+                document::processor::document_filename(section, doc, &self.config)
+            }
+            "document-suffix" => document::processor::document_suffix(section, doc, &self.config),
             "package-tree" => {
                 fpm::library::package_tree::processor(section, doc, &self.config).await
             }


### PR DESCRIPTION
- [Doc PR](https://github.com/FifthTry/fpm.dev/pull/57)

Since we need to get `id` `full-id` and `filename` to power `document-readers` and `document-writers`, so creating processors `document-id`, `document-full-id`, `document-filename` and `document-suffix`