### PR TITLE
Introducing new BG color as `fpm.color.main.background.code`

### DIFF
--- a/ftd/design.ftd
+++ b/ftd/design.ftd
@@ -205,11 +205,16 @@ dark: #585656
 light: rgba(0, 0, 0, 0.8)
 dark: rgba(0, 0, 0, 0.8)
 
+-- ftd.color code-:
+light: #2B303B
+dark: #2B303B
+
 -- ftd.background-colors background-:
 base: $base-
 step-1: $step-1-
 step-2: $step-2-
 overlay: $overlay-
+code: $code-
 
 -- ftd.color border-:
 light: #434547


### PR DESCRIPTION
We have introduced new BG color for code block as `#2B303B` which helps all `FTD` themes to use Code-Block with same BG inside any component.

Usage:
```ftd
-- ftd.column:
background-color: $fpm.color.main.background.code`
```

Note: Can be only merged once https://github.com/FifthTry/ftd/pull/337 is merged.