### PR TITLE
Fix: Font on build and image (dark mode) on serve

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -85,8 +85,7 @@ async fn cr_add(config: &fpm::Config, file: &str, cr: usize) -> fpm::Result<()> 
     let cr_file_path = config.cr_path(cr).join(file);
 
     if file_path.exists() {
-        let content = tokio::fs::read(&file_path).await?;
-        fpm::utils::update(&cr_file_path, content.as_slice()).await?;
+        fpm::utils::copy(&file_path, &cr_file_path).await?;
     } else {
         fpm::utils::update(&cr_file_path, vec![].as_slice()).await?;
     }

--- a/src/commands/build2.rs
+++ b/src/commands/build2.rs
@@ -6,6 +6,10 @@ pub async fn build2(
 ) -> fpm::Result<()> {
     tokio::fs::create_dir_all(config.build_dir()).await?;
     let documents = get_documents_for_current_package(config).await?;
+
+    // No need to build static files when file is passed during fpm build (no-static behaviour)
+    let no_static: bool = file.is_some();
+
     for main in documents.values() {
         if file.is_some() && file != Some(main.get_id().as_str()) {
             continue;
@@ -18,9 +22,6 @@ pub async fn build2(
             config.package.name.as_str(),
             main.get_id()
         );
-
-        // No need to build static files when file is passed during fpm build (no-static behaviour)
-        let no_static: bool = file.is_some();
 
         match main {
             fpm::File::Ftd(doc) => {
@@ -97,6 +98,10 @@ pub async fn build2(
             .as_str(),
             start,
         );
+    }
+
+    if true || !no_static {
+        config.download_fonts().await?;
     }
     Ok(())
 }

--- a/src/commands/build2.rs
+++ b/src/commands/build2.rs
@@ -100,7 +100,7 @@ pub async fn build2(
         );
     }
 
-    if true || !no_static {
+    if !no_static {
         config.download_fonts().await?;
     }
     Ok(())

--- a/src/commands/revert.rs
+++ b/src/commands/revert.rs
@@ -24,8 +24,7 @@ pub async fn revert(config: &fpm::Config, path: &str) -> fpm::Result<()> {
 
     if let Some(server_version) = file_status.get_latest_version() {
         let server_path = config.history_path(path, server_version);
-        let content = tokio::fs::read(&server_path).await?;
-        fpm::utils::update(&config.root.join(path), content.as_slice()).await?;
+        fpm::utils::copy(&server_path, &config.root.join(path)).await?;
         if let Some(workspace_entry) = workspace.get_mut(path) {
             workspace_entry.version = Some(server_version);
             workspace_entry.deleted = None;

--- a/src/font.rs
+++ b/src/font.rs
@@ -29,6 +29,28 @@ fn append_src(kind: &str, value: &Option<String>, collector: &mut Vec<String>) {
 }
 
 impl Font {
+    pub fn get_url(&self) -> Option<String> {
+        if self.woff.is_some() {
+            return self.woff.clone();
+        }
+        if self.woff2.is_some() {
+            return self.woff2.clone();
+        }
+        if self.truetype.is_some() {
+            return self.truetype.clone();
+        }
+        if self.opentype.is_some() {
+            return self.opentype.clone();
+        }
+        if self.embedded_opentype.is_some() {
+            return self.embedded_opentype.clone();
+        }
+        if self.svg.is_some() {
+            return self.svg.clone();
+        }
+        None
+    }
+
     pub fn to_html(&self, package_name: &str) -> String {
         let mut attrs = vec![];
         if let Some(ref ur) = self.unicode_range {

--- a/src/package_doc.rs
+++ b/src/package_doc.rs
@@ -218,7 +218,11 @@ impl fpm::Package {
                     .starts_with("image/")
                     && remaining.ends_with("-dark") =>
             {
-                format!("{}.{}", remaining.trim_end_matches("-dark"), ext)
+                format!(
+                    "{}.{}",
+                    remaining.trim_matches('/').trim_end_matches("-dark"),
+                    ext
+                )
             }
             _ => {
                 return Err(fpm::Error::PackageError {
@@ -242,9 +246,10 @@ impl fpm::Package {
                 }
             }
         };
+        let id = id.trim_matches('/');
 
         if let Ok(response) = self.fs_fetch_by_id(new_id.as_str(), package_root).await {
-            tokio::fs::copy(root.join(new_id), root.join(id)).await?;
+            fpm::utils::copy(&root.join(new_id), &root.join(id)).await?;
             return Ok(response);
         }
 
@@ -253,7 +258,7 @@ impl fpm::Package {
             .await
         {
             Ok(response) => {
-                tokio::fs::copy(root.join(new_id), root.join(id)).await?;
+                fpm::utils::copy(&root.join(new_id), &root.join(id)).await?;
                 Ok(response)
             }
             Err(e) => Err(e),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -476,6 +476,11 @@ pub(crate) async fn update1(
     )
 }
 
+pub(crate) async fn copy(from: &camino::Utf8PathBuf, to: &camino::Utf8PathBuf) -> fpm::Result<()> {
+    let content = tokio::fs::read(from).await?;
+    fpm::utils::update(to, content.as_slice()).await
+}
+
 pub(crate) async fn update(root: &camino::Utf8PathBuf, data: &[u8]) -> fpm::Result<()> {
     use tokio::io::AsyncWriteExt;
 


### PR DESCRIPTION
This PR fixes the following issues:

1. Fonts were not applying to the text as they were not downloaded on `fpm build`. 
2. Image on dark mode was not served when using `fpm serve`.